### PR TITLE
feat(auth): spring security 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
 
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/io/github/bunmo/common/exception/BusinessException.java
+++ b/src/main/java/io/github/bunmo/common/exception/BusinessException.java
@@ -1,9 +1,9 @@
 package io.github.bunmo.common.exception;
 
-public class CustomException extends RuntimeException {
+public class BusinessException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode) {
+    public BusinessException(ErrorCode errorCode) {
         super(errorCode.message());
         this.errorCode = errorCode;
     }

--- a/src/main/java/io/github/bunmo/common/exception/ErrorCode.java
+++ b/src/main/java/io/github/bunmo/common/exception/ErrorCode.java
@@ -1,10 +1,12 @@
 package io.github.bunmo.common.exception;
 
+import org.springframework.http.HttpStatus;
+
 /**
 * 각 도메인에서 구현
 */
 public interface ErrorCode {
-    int statusCode();
+    HttpStatus statusCode();
     String code();
     String message();
 }

--- a/src/main/java/io/github/bunmo/common/web/ApiResponse.java
+++ b/src/main/java/io/github/bunmo/common/web/ApiResponse.java
@@ -3,17 +3,22 @@ package io.github.bunmo.common.web;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.github.bunmo.common.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"code", "message", "data", "errors"})
-record ApiResponse<T>(
-        String code,
-        String message,
-        T data,
-        List<FieldError> errors
-) {
+public class ApiResponse<T> {
+    private final String code;
+    private final String message;
+    private final T data;
+    private final List<FieldError> errors;
+
     public record FieldError(String field, String message) {}
 
     public static <T> ApiResponse<T> success(T data) {

--- a/src/main/java/io/github/bunmo/common/web/ApiResponse.java
+++ b/src/main/java/io/github/bunmo/common/web/ApiResponse.java
@@ -21,8 +21,8 @@ public class ApiResponse<T> {
 
     public record FieldError(String field, String message) {}
 
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>("OK", "success", data, null);
+    public static <T> ApiResponse<T> success(ResultCode resultCode, T data) {
+        return new ApiResponse<>(resultCode.code(), resultCode.message(), data, null);
     }
 
     public static ApiResponse<Void> error(ErrorCode errorCode) {

--- a/src/main/java/io/github/bunmo/common/web/GlobalControllerAdvice.java
+++ b/src/main/java/io/github/bunmo/common/web/GlobalControllerAdvice.java
@@ -1,6 +1,6 @@
 package io.github.bunmo.common.web;
 
-import io.github.bunmo.common.exception.CustomException;
+import io.github.bunmo.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalControllerAdvice {
 
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<?> handleCustomException(CustomException e) {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<?> handleCustomException(BusinessException e) {
         log.debug(e.getMessage());
         return ResponseEntity
                 .status(e.errorCode().statusCode())

--- a/src/main/java/io/github/bunmo/common/web/HealthCheckController.java
+++ b/src/main/java/io/github/bunmo/common/web/HealthCheckController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class HealthCheckController {
     @GetMapping("/health")
-    public ApiResponse<String> healthCheck() {
-        return ApiResponse.success("I'm OK");
+    public String healthCheck() {
+        return "I'm OK";
     }
 }

--- a/src/main/java/io/github/bunmo/common/web/ResultCode.java
+++ b/src/main/java/io/github/bunmo/common/web/ResultCode.java
@@ -1,0 +1,9 @@
+package io.github.bunmo.common.web;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResultCode {
+    HttpStatus statusCode();
+    String code();
+    String message();
+}

--- a/src/main/java/io/github/bunmo/member/AuthType.java
+++ b/src/main/java/io/github/bunmo/member/AuthType.java
@@ -1,5 +1,0 @@
-package io.github.bunmo.member;
-
-public enum AuthType {
-    KAKAO, APPLE
-}

--- a/src/main/java/io/github/bunmo/member/Gender.java
+++ b/src/main/java/io/github/bunmo/member/Gender.java
@@ -1,5 +1,0 @@
-package io.github.bunmo.member;
-
-public enum Gender {
-    FEMALE, MALE, ANONYMOUS;
-}

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
@@ -47,7 +47,7 @@ public class Member {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "updated_at", nullable = false, updatable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
     public String email() {

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
@@ -1,5 +1,10 @@
-package io.github.bunmo.member;
+package io.github.bunmo.member.infrastructure.domain;
 
+import io.github.bunmo.member.infrastructure.domain.enums.ActiveType;
+import io.github.bunmo.member.infrastructure.domain.enums.AuthType;
+import io.github.bunmo.member.infrastructure.domain.enums.RoleType;
+import io.github.bunmo.member.infrastructure.domain.vo.MemberLocation;
+import io.github.bunmo.member.infrastructure.domain.vo.MemberProfile;
 import jakarta.persistence.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -15,6 +20,8 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String email;
+
     @Embedded
     private MemberProfile memberProfile;
 
@@ -25,6 +32,9 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(name = "active_type", nullable = false)
     private ActiveType activeType;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType role;
 
     @Embedded
     private MemberLocation location;
@@ -39,4 +49,12 @@ public class Member {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false, updatable = false)
     private LocalDateTime updatedAt;
+
+    public String email() {
+        return this.email;
+    }
+
+    public RoleType role() {
+        return this.role;
+    }
 }

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/ActiveType.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/ActiveType.java
@@ -1,4 +1,4 @@
-package io.github.bunmo.member;
+package io.github.bunmo.member.infrastructure.domain.enums;
 
 public enum ActiveType {
     ACTIVE, INACTIVE, BANNED, WITHDRAWAL

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/AuthType.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/AuthType.java
@@ -1,0 +1,5 @@
+package io.github.bunmo.member.infrastructure.domain.enums;
+
+public enum AuthType {
+    KAKAO, APPLE
+}

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/Gender.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package io.github.bunmo.member.infrastructure.domain.enums;
+
+public enum Gender {
+    FEMALE, MALE, ANONYMOUS;
+}

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/RoleType.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/RoleType.java
@@ -1,0 +1,6 @@
+package io.github.bunmo.member.infrastructure.domain.enums;
+
+public enum RoleType {
+    ADMIN,
+    MEMBER,
+}

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/vo/MemberLocation.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/vo/MemberLocation.java
@@ -1,4 +1,4 @@
-package io.github.bunmo.member;
+package io.github.bunmo.member.infrastructure.domain.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/vo/MemberProfile.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/vo/MemberProfile.java
@@ -1,5 +1,6 @@
-package io.github.bunmo.member;
+package io.github.bunmo.member.infrastructure.domain.vo;
 
+import io.github.bunmo.member.infrastructure.domain.enums.Gender;
 import jakarta.persistence.Embeddable;
 
 @Embeddable

--- a/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package io.github.bunmo.member.infrastructure.repository;
+
+import io.github.bunmo.member.infrastructure.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/io/github/bunmo/report/ReportedUserHistory.java
+++ b/src/main/java/io/github/bunmo/report/ReportedUserHistory.java
@@ -1,4 +1,4 @@
-package io.github.bunmo.common.report;
+package io.github.bunmo.report;
 
 import jakarta.persistence.*;
 

--- a/src/main/java/io/github/bunmo/security/CustomUserDetails.java
+++ b/src/main/java/io/github/bunmo/security/CustomUserDetails.java
@@ -1,0 +1,39 @@
+package io.github.bunmo.security;
+
+import io.github.bunmo.member.infrastructure.entity.RoleType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private String email;
+    private RoleType role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_" + role.toString());
+
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/src/main/java/io/github/bunmo/security/CustomUserDetails.java
+++ b/src/main/java/io/github/bunmo/security/CustomUserDetails.java
@@ -1,30 +1,32 @@
 package io.github.bunmo.security;
 
+import io.github.bunmo.member.infrastructure.domain.Member;
 import io.github.bunmo.member.infrastructure.domain.enums.RoleType;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 public class CustomUserDetails implements UserDetails {
     private String email;
     private RoleType role;
 
+    private CustomUserDetails(String email, RoleType role) {
+        this.email = email;
+        this.role = role;
+    }
+
+    public static CustomUserDetails from(Member member) {
+        return new CustomUserDetails(member.email(), member.role());
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        List<String> roles = new ArrayList<>();
-        roles.add("ROLE_" + role.toString());
-
-        return roles.stream()
-                .map(SimpleGrantedAuthority::new)
-                .toList();
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.toString()));
     }
 
     @Override

--- a/src/main/java/io/github/bunmo/security/CustomUserDetails.java
+++ b/src/main/java/io/github/bunmo/security/CustomUserDetails.java
@@ -1,6 +1,6 @@
 package io.github.bunmo.security;
 
-import io.github.bunmo.member.infrastructure.entity.RoleType;
+import io.github.bunmo.member.infrastructure.domain.enums.RoleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/io/github/bunmo/security/JwtFilter.java
+++ b/src/main/java/io/github/bunmo/security/JwtFilter.java
@@ -1,0 +1,47 @@
+package io.github.bunmo.security;
+
+import io.github.bunmo.security.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) {
+            Authentication authentication = jwtUtil.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다.");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package io.github.bunmo.security.config;
 import io.github.bunmo.security.JwtFilter;
 import io.github.bunmo.security.jwt.JwtAccessDeniedHandler;
 import io.github.bunmo.security.jwt.JwtAuthenticationEntryPoint;
-import io.github.bunmo.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +27,7 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final AuthenticationConfiguration authenticationConfiguration;
-    private final JwtUtil jwtUtil;
+    private final JwtFilter jwtFilter;
 
     @Bean
     public AuthenticationManager authenticationManager() throws Exception {
@@ -69,7 +68,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/member/login", "/api/v1/member/signup", "/api-docs/**", "/swagger-ui/**", "/swagger-ui/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
 
     }

--- a/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
@@ -1,0 +1,76 @@
+package io.github.bunmo.security.config;
+
+import io.github.bunmo.security.JwtFilter;
+import io.github.bunmo.security.jwt.JwtAccessDeniedHandler;
+import io.github.bunmo.security.jwt.JwtAuthenticationEntryPoint;
+import io.github.bunmo.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration configuration = new CorsConfiguration();
+            configuration.setAllowedOrigins(Collections.singletonList("http://localhost:6004"));
+            configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+            configuration.setAllowCredentials(true);
+            configuration.setAllowedHeaders(Collections.singletonList("*"));
+            configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+            configuration.setAllowCredentials(true);
+            return configuration;
+        };
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
+        return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/member/login", "/api/v1/member/signup", "/api-docs/**", "/swagger-ui/**", "/swagger-ui/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .build();
+
+    }
+}

--- a/src/main/java/io/github/bunmo/security/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/bunmo/security/exception/AuthErrorCode.java
@@ -1,27 +1,28 @@
 package io.github.bunmo.security.exception;
 
 import io.github.bunmo.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
 
 public enum AuthErrorCode implements ErrorCode {
-    INVALID_JWT_TOKEN(401, "UNAUTHORIZED_001", "유효하지 않은 토큰입니다"),
-    EXPIRED_JWT_TOKEN(401, "UNAUTHORIZED_002", "만료된 토큰입니다"),
-    UNSUPPORTED_JWT_TOKEN(401, "UNAUTHORIZED_003", "지원하지 않는 토큰입니다"),
-    ACCESS_DENIED(401, "UNAUTHORIZED_004", "접근이 거부되었습니다"),
-    UNAUTHORIZED(401, "UNAUTHORIZED_005", "인증이 필요합니다"),
+    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_001", "유효하지 않은 토큰입니다"),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_002", "만료된 토큰입니다"),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_003", "지원하지 않는 토큰입니다"),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_004", "접근이 거부되었습니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_005", "인증이 필요합니다"),
     ;
 
-    private final int statusCode;
+    private final HttpStatus statusCode;
     private final String code;
     private final String message;
 
-    AuthErrorCode(int statusCode, String code, String message) {
+    AuthErrorCode(HttpStatus statusCode, String code, String message) {
         this.statusCode = statusCode;
         this.code = code;
         this.message = message;
     }
 
     @Override
-    public int statusCode() {
+    public HttpStatus statusCode() {
         return this.statusCode;
     }
 

--- a/src/main/java/io/github/bunmo/security/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/bunmo/security/exception/AuthErrorCode.java
@@ -1,0 +1,37 @@
+package io.github.bunmo.security.exception;
+
+import io.github.bunmo.common.exception.ErrorCode;
+
+public enum AuthErrorCode implements ErrorCode {
+    INVALID_JWT_TOKEN(401, "UNAUTHORIZED_001", "유효하지 않은 토큰입니다"),
+    EXPIRED_JWT_TOKEN(401, "UNAUTHORIZED_002", "만료된 토큰입니다"),
+    UNSUPPORTED_JWT_TOKEN(401, "UNAUTHORIZED_003", "지원하지 않는 토큰입니다"),
+    ACCESS_DENIED(401, "UNAUTHORIZED_004", "접근이 거부되었습니다"),
+    UNAUTHORIZED(401, "UNAUTHORIZED_005", "인증이 필요합니다"),
+    ;
+
+    private final int statusCode;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(int statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int statusCode() {
+        return this.statusCode;
+    }
+
+    @Override
+    public String code() {
+        return this.code;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/io/github/bunmo/security/exception/AuthException.java
+++ b/src/main/java/io/github/bunmo/security/exception/AuthException.java
@@ -1,0 +1,16 @@
+package io.github.bunmo.security.exception;
+
+import io.github.bunmo.common.exception.ErrorCode;
+
+public class AuthException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode errorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/io/github/bunmo/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/io/github/bunmo/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package io.github.bunmo.security.jwt;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bunmo.security.exception.AuthErrorCode;
+import io.github.bunmo.common.web.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final AccessDeniedException accessDeniedException
+    ) throws IOException {
+        ApiResponse<Void> apiResponse = ApiResponse.error(AuthErrorCode.ACCESS_DENIED);
+
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/io/github/bunmo/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/io/github/bunmo/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package io.github.bunmo.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bunmo.common.web.ApiResponse;
+import io.github.bunmo.security.exception.AuthErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ApiResponse<Void> apiResponse = ApiResponse.error(AuthErrorCode.UNAUTHORIZED);
+
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
+++ b/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
@@ -57,16 +57,13 @@ public class JwtUtil {
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             log.error("잘 못된 JWT 서명입니다");
-//            throw new AuthException(AuthErrorCode.INVALID_JWT_TOKEN);
         } catch (ExpiredJwtException e) {
             log.error("만료된 JWT 토큰입니다.");
             throw new AuthException(AuthErrorCode.EXPIRED_JWT_TOKEN);
         } catch (UnsupportedJwtException e) {
             log.error("지원되지 않는 JWT 토큰입니다.");
-//            throw new AuthException(AuthErrorCode.UNSUPPORTED_JWT_TOKEN);
         } catch (IllegalArgumentException e) {
             log.error("JWT 토큰이 잘못되었습니다.");
-//            throw new AuthException(AuthErrorCode.ACCESS_DENIED);
         }
         return false;
     }

--- a/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
+++ b/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
@@ -84,6 +84,10 @@ public class JwtUtil {
         return new UsernamePasswordAuthenticationToken(principle, token, authorities);
     }
 
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
+    }
+
     private String generateToken(Authentication authentication, long expireTime) {
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)

--- a/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
+++ b/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
@@ -1,0 +1,112 @@
+package io.github.bunmo.security.jwt;
+
+import io.github.bunmo.security.exception.AuthErrorCode;
+import io.github.bunmo.security.exception.AuthException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    private final SecretKey key;
+    private final long accessTokenExpireTime;
+    private final long refreshTokenExpireTime;
+    private static final String AUTHORITIES_KEY = "roles";
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token.expire-time}") long accessTokenExpireTime,
+            @Value("${jwt.refresh-token.expire-time}") long refreshTokenExpireTime
+    ) {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpireTime = accessTokenExpireTime;
+        this.refreshTokenExpireTime = refreshTokenExpireTime;
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        return generateToken(authentication, accessTokenExpireTime);
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return generateToken(authentication, refreshTokenExpireTime);
+    }
+
+    public Long getAccessTokenValidity() {
+        return accessTokenExpireTime / 1000;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("잘 못된 JWT 서명입니다");
+//            throw new AuthException(AuthErrorCode.INVALID_JWT_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다.");
+            throw new AuthException(AuthErrorCode.EXPIRED_JWT_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다.");
+//            throw new AuthException(AuthErrorCode.UNSUPPORTED_JWT_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 잘못되었습니다.");
+//            throw new AuthException(AuthErrorCode.ACCESS_DENIED);
+        }
+        return false;
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .filter(auth -> !auth.trim().isEmpty())
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
+        User principle = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principle, token, authorities);
+    }
+
+    private String generateToken(Authentication authentication, long expireTime) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date now = new Date(System.currentTimeMillis());
+        Date expiryDate = new Date(System.currentTimeMillis() + expireTime);
+
+        return Jwts.builder()
+                .subject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+}

--- a/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
+++ b/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
@@ -23,6 +23,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.ACCESS_DENIED));
 
-        return new CustomUserDetails(member.email(), member.role());
+        return CustomUserDetails.from(member);
     }
 }

--- a/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
+++ b/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
@@ -1,10 +1,10 @@
 package io.github.bunmo.security.service;
 
+import io.github.bunmo.member.infrastructure.domain.Member;
+import io.github.bunmo.member.infrastructure.repository.MemberRepository;
 import io.github.bunmo.security.CustomUserDetails;
 import io.github.bunmo.security.exception.AuthErrorCode;
 import io.github.bunmo.security.exception.AuthException;
-import io.github.bunmo.member.infrastructure.entity.Member;
-import io.github.bunmo.member.infrastructure.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
+++ b/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package io.github.bunmo.security.service;
+
+import io.github.bunmo.security.CustomUserDetails;
+import io.github.bunmo.security.exception.AuthErrorCode;
+import io.github.bunmo.security.exception.AuthException;
+import io.github.bunmo.member.infrastructure.entity.Member;
+import io.github.bunmo.member.infrastructure.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.ACCESS_DENIED));
+
+        return new CustomUserDetails(member.email(), member.role());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,9 @@ springdoc:
     tags-sorter: alpha
     doc-expansion: none
 
+jwt:
+  secret: +911VYr4eRTnV4Ubb2i/GhmQjs9CCPnfVhxdXe/sX0l6rO4budtCOK4xCFUbspeiplwjZCotXsYsKGKi0DlIKw==
+  access-token:
+    expire-time: 86400000
+  refresh-token:
+    expire-time: 259200000


### PR DESCRIPTION
# 작업 내용
- JWT 토큰 인증 가능하도록 스프링 시큐리티 설정

# 리뷰 요구사항
- 해당 pr 완료되면 카카오 로그인 진행하겠습니다. SNS 로그인 사용하게 되면 비밀번호가 필요 없을 듯 하여 비밀번호는 대응하지 않았습니다 
- Spring Security에서 CustomExcpetion 정의 후 GlobalControllerAdvice로 에러를 잡아 처리하는 것이 불가능 하다고 합니다. AuthErrorCode와 AuthException을 만들었지만 실제로 사용되는 부분은 JwtAccessDeniedHandler, JwtAuthenticationEntryPoint 입니다
-  formLogin/httpBasic 을 disable 하게 되면 Authentication Provider에 의해 실행되어야하는 UserDetailsService가 호출되지 않는다고 합니다. 다만 UserDetalsService가 데이터베이스로 부터 유효한 사용자가 맞는지 체크하는데 사용되고, JwtFilter에서 필요해 구현 뒤 직접 호출 하는 방식으로 사용되었습니다 
