### PR TITLE
[FEATURE] 카카오 로그인 기능 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Database Configuration
+DATABASE_URL=jdbc:mysql://localhost:3306/bunmo?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+DATABASE_USERNAME=your_db_username
+DATABASE_PASSWORD=your_db_password
+
+# JWT Configuration
+JWT_SECRET=your_base64_encoded_secret_key
+JWT_ACCESS_TOKEN_EXPIRE_TIME=86400000
+JWT_REFRESH_TOKEN_EXPIRE_TIME=259200000
+
+# Kakao OAuth Configuration
+KAKAO_CLIENT_ID=kakao_client_id
+KAKAO_CLIENT_SECRET=kakao_client_secret
+KAKAO_REDIRECT_URI=http://localhost:18080/api/v1/oauth2/kakao
+
+# Spring Profile
+SPRING_PROFILES_ACTIVE=prod

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,5 @@ out/
 .env.*.local
 
 ## application.yml ###
-.\src\main\resources\application-dev.yml
-.\src\main\resources\application-prod.yml
+./src/main/resources/application-dev.yml
+./src/main/resources/application-prod.yml

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment Variables ###
+.env
+.env.local
+.env.*.local
+
+## application.yml ###
+.\src\main\resources\application-dev.yml
+.\src\main\resources\application-prod.yml

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/io/github/bunmo/BunmoApplication.java
+++ b/src/main/java/io/github/bunmo/BunmoApplication.java
@@ -2,9 +2,11 @@ package io.github.bunmo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class BunmoApplication {
 

--- a/src/main/java/io/github/bunmo/auth/config/KakaoOAuthProperties.java
+++ b/src/main/java/io/github/bunmo/auth/config/KakaoOAuthProperties.java
@@ -8,6 +8,8 @@ public record KakaoOAuthProperties(
         String clientSecret,
         String redirectUri,
         String tokenUri,
-        String userInfoUri
+        String tokenPath,
+        String userInfoUri,
+        String userInfoPath
 ) {
 }

--- a/src/main/java/io/github/bunmo/auth/config/KakaoOAuthProperties.java
+++ b/src/main/java/io/github/bunmo/auth/config/KakaoOAuthProperties.java
@@ -1,0 +1,13 @@
+package io.github.bunmo.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth2.kakao")
+public record KakaoOAuthProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        String tokenUri,
+        String userInfoUri
+) {
+}

--- a/src/main/java/io/github/bunmo/auth/controller/AuthController.java
+++ b/src/main/java/io/github/bunmo/auth/controller/AuthController.java
@@ -1,0 +1,37 @@
+package io.github.bunmo.auth.controller;
+
+import io.github.bunmo.auth.dto.AuthResultCode;
+import io.github.bunmo.auth.dto.request.KakaoLoginRequest;
+import io.github.bunmo.auth.dto.response.TokenResponse;
+import io.github.bunmo.auth.service.AuthService;
+import io.github.bunmo.common.web.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 통해 로그인 또는 회원가입을 진행합니다.")
+    @PostMapping("/oauth2/kakao")
+    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request
+    ) {
+        TokenResponse response = authService.kakaoLogin(request);
+        AuthResultCode resultCode = response.isNewMember()
+                ? AuthResultCode.SIGNUP_SUCCESS
+                : AuthResultCode.LOGIN_SUCCESS;
+        return ResponseEntity.status(resultCode.statusCode())
+                .body(ApiResponse.success(resultCode, response));
+    }
+}

--- a/src/main/java/io/github/bunmo/auth/dto/AuthResultCode.java
+++ b/src/main/java/io/github/bunmo/auth/dto/AuthResultCode.java
@@ -1,0 +1,35 @@
+package io.github.bunmo.auth.dto;
+
+import io.github.bunmo.common.web.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthResultCode implements ResultCode {
+    LOGIN_SUCCESS(OK, "AUTH_001", "로그인 성공"),
+    SIGNUP_SUCCESS(CREATED, "AUTH_002", "회원가입 성공");
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus statusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/io/github/bunmo/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/io/github/bunmo/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,9 @@
+package io.github.bunmo.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest(
+        @NotBlank(message = "인가 코드는 필수입니다")
+        String code
+) {
+}

--- a/src/main/java/io/github/bunmo/auth/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/io/github/bunmo/auth/dto/response/KakaoTokenResponse.java
@@ -1,22 +1,16 @@
 package io.github.bunmo.auth.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoTokenResponse(
-        @JsonProperty("token_type")
         String tokenType,
-        @JsonProperty("access_token")
         String accessToken,
-        @JsonProperty("id_token")
         String idToken,
-        @JsonProperty("expires_in")
         Integer expiresIn,
-        @JsonProperty("refresh_token")
         String refreshToken,
-        @JsonProperty("refresh_token_expires_in")
         Integer refreshTokenExpiresIn,
-        @JsonProperty("scope")
         String scope
 ) {
 }

--- a/src/main/java/io/github/bunmo/auth/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/io/github/bunmo/auth/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,22 @@
+package io.github.bunmo.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.RequiredArgsConstructor;
+
+public record KakaoTokenResponse(
+        @JsonProperty("token_type")
+        String tokenType,
+        @JsonProperty("access_token")
+        String accessToken,
+        @JsonProperty("id_token")
+        String idToken,
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+        @JsonProperty("refresh_token")
+        String refreshToken,
+        @JsonProperty("refresh_token_expires_in")
+        Integer refreshTokenExpiresIn,
+        @JsonProperty("scope")
+        String scope
+) {
+}

--- a/src/main/java/io/github/bunmo/auth/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/io/github/bunmo/auth/dto/response/KakaoUserInfoResponse.java
@@ -1,0 +1,155 @@
+package io.github.bunmo.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.HashMap;
+
+public record KakaoUserInfoResponse(
+        @JsonProperty("id")
+        Long id,
+        @JsonProperty("has_signed_up")
+        Boolean hasSignedUp,
+        @JsonProperty("connected_at")
+        Date connectedAt,
+        @JsonProperty("synched_at")
+        Date synchedAt,
+        @JsonProperty("properties")
+        HashMap<String, String> properties,
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount,
+        @JsonProperty("for_partner")
+        Partner partner
+) {
+    public record KakaoAccount(
+            @JsonProperty("profile_needs_agreement")
+            Boolean isProfileAgree,
+
+            //닉네임 제공 동의 여부
+            @JsonProperty("profile_nickname_needs_agreement")
+            Boolean isNickNameAgree,
+
+            //프로필 사진 제공 동의 여부
+            @JsonProperty("profile_image_needs_agreement")
+            Boolean isProfileImageAgree,
+
+            //사용자 프로필 정보
+            @JsonProperty("profile")
+            Profile profile,
+
+            //이름 제공 동의 여부
+            @JsonProperty("name_needs_agreement")
+            Boolean isNameAgree,
+
+            //카카오계정 이름
+            @JsonProperty("name")
+            String name,
+
+            //이메일 제공 동의 여부
+            @JsonProperty("email_needs_agreement")
+            Boolean isEmailAgree,
+
+            //이메일이 유효 여부
+            // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
+            @JsonProperty("is_email_valid")
+            Boolean isEmailValid,
+
+            //이메일이 인증 여부
+            //true : 인증된 이메일, false : 인증되지 않은 이메일
+            @JsonProperty("is_email_verified")
+            Boolean isEmailVerified,
+
+            //카카오계정 대표 이메일
+            @JsonProperty("email")
+            String email,
+
+            //연령대 제공 동의 여부
+            @JsonProperty("age_range_needs_agreement")
+            Boolean isAgeAgree,
+
+            //연령대
+            //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+            @JsonProperty("age_range")
+            String ageRange,
+
+            //출생 연도 제공 동의 여부
+            @JsonProperty("birthyear_needs_agreement")
+            Boolean isBirthYearAgree,
+
+            //출생 연도 (YYYY 형식)
+            @JsonProperty("birthyear")
+            String birthYear,
+
+            //생일 제공 동의 여부
+            @JsonProperty("birthday_needs_agreement")
+            Boolean isBirthDayAgree,
+
+            //생일 (MMDD 형식)
+            @JsonProperty("birthday")
+            String birthDay,
+
+            //생일 타입
+            // SOLAR(양력) 혹은 LUNAR(음력)
+            @JsonProperty("birthday_type")
+            String birthDayType,
+
+            //성별 제공 동의 여부
+            @JsonProperty("gender_needs_agreement")
+            Boolean isGenderAgree,
+
+            //성별
+            @JsonProperty("gender")
+            String gender,
+
+            //전화번호 제공 동의 여부
+            @JsonProperty("phone_number_needs_agreement")
+            Boolean isPhoneNumberAgree,
+
+            //전화번호
+            //국내 번호인 경우 +82 00-0000-0000 형식
+            @JsonProperty("phone_number")
+            String phoneNumber,
+
+            //CI 동의 여부
+            @JsonProperty("ci_needs_agreement")
+            Boolean isCIAgree,
+
+            //CI, 연계 정보
+            @JsonProperty("ci")
+            String ci,
+
+            //CI 발급 시각, UTC
+            @JsonProperty("ci_authenticated_at")
+            Date ciCreatedAt
+    ) {
+        public record Profile(
+                //닉네임
+                @JsonProperty("nickname")
+                String nickName,
+
+                //프로필 미리보기 이미지
+                @JsonProperty("thumbnail_image_url")
+                String thumbnailImageUrl,
+
+                //프로필 사진 URL
+                @JsonProperty("profile_image_url")
+                String profileImageUrl,
+
+                //프로필 사진 URL 기본 프로필인지 여부
+                //true : 기본 프로필, false : 사용자 등록
+                @JsonProperty("is_default_image")
+                String isDefaultImage,
+
+                //닉네임이 기본 닉네임인지 여부
+                //true : 기본 닉네임, false : 사용자 등록
+                @JsonProperty("is_default_nickname")
+                Boolean isDefaultNickName
+        ){ }
+    }
+
+    public record Partner(
+            //고유 ID
+            @JsonProperty("uuid")
+            String uuid
+    ) {}
+}

--- a/src/main/java/io/github/bunmo/auth/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/io/github/bunmo/auth/dto/response/KakaoUserInfoResponse.java
@@ -2,8 +2,7 @@ package io.github.bunmo.auth.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Date;
-import java.util.HashMap;
+import java.time.Instant;
 
 public record KakaoUserInfoResponse(
         @JsonProperty("id")
@@ -11,144 +10,27 @@ public record KakaoUserInfoResponse(
         @JsonProperty("has_signed_up")
         Boolean hasSignedUp,
         @JsonProperty("connected_at")
-        Date connectedAt,
+        Instant connectedAt,
         @JsonProperty("synched_at")
-        Date synchedAt,
-        @JsonProperty("properties")
-        HashMap<String, String> properties,
+        Instant synchedAt,
         @JsonProperty("kakao_account")
         KakaoAccount kakaoAccount,
         @JsonProperty("for_partner")
         Partner partner
 ) {
     public record KakaoAccount(
-            @JsonProperty("profile_needs_agreement")
-            Boolean isProfileAgree,
-
-            //닉네임 제공 동의 여부
-            @JsonProperty("profile_nickname_needs_agreement")
-            Boolean isNickNameAgree,
-
-            //프로필 사진 제공 동의 여부
-            @JsonProperty("profile_image_needs_agreement")
-            Boolean isProfileImageAgree,
-
-            //사용자 프로필 정보
             @JsonProperty("profile")
-            Profile profile,
-
-            //이름 제공 동의 여부
-            @JsonProperty("name_needs_agreement")
-            Boolean isNameAgree,
-
-            //카카오계정 이름
-            @JsonProperty("name")
-            String name,
-
-            //이메일 제공 동의 여부
-            @JsonProperty("email_needs_agreement")
-            Boolean isEmailAgree,
-
-            //이메일이 유효 여부
-            // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
-            @JsonProperty("is_email_valid")
-            Boolean isEmailValid,
-
-            //이메일이 인증 여부
-            //true : 인증된 이메일, false : 인증되지 않은 이메일
-            @JsonProperty("is_email_verified")
-            Boolean isEmailVerified,
-
-            //카카오계정 대표 이메일
-            @JsonProperty("email")
-            String email,
-
-            //연령대 제공 동의 여부
-            @JsonProperty("age_range_needs_agreement")
-            Boolean isAgeAgree,
-
-            //연령대
-            //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
-            @JsonProperty("age_range")
-            String ageRange,
-
-            //출생 연도 제공 동의 여부
-            @JsonProperty("birthyear_needs_agreement")
-            Boolean isBirthYearAgree,
-
-            //출생 연도 (YYYY 형식)
-            @JsonProperty("birthyear")
-            String birthYear,
-
-            //생일 제공 동의 여부
-            @JsonProperty("birthday_needs_agreement")
-            Boolean isBirthDayAgree,
-
-            //생일 (MMDD 형식)
-            @JsonProperty("birthday")
-            String birthDay,
-
-            //생일 타입
-            // SOLAR(양력) 혹은 LUNAR(음력)
-            @JsonProperty("birthday_type")
-            String birthDayType,
-
-            //성별 제공 동의 여부
-            @JsonProperty("gender_needs_agreement")
-            Boolean isGenderAgree,
-
-            //성별
-            @JsonProperty("gender")
-            String gender,
-
-            //전화번호 제공 동의 여부
-            @JsonProperty("phone_number_needs_agreement")
-            Boolean isPhoneNumberAgree,
-
-            //전화번호
-            //국내 번호인 경우 +82 00-0000-0000 형식
-            @JsonProperty("phone_number")
-            String phoneNumber,
-
-            //CI 동의 여부
-            @JsonProperty("ci_needs_agreement")
-            Boolean isCIAgree,
-
-            //CI, 연계 정보
-            @JsonProperty("ci")
-            String ci,
-
-            //CI 발급 시각, UTC
-            @JsonProperty("ci_authenticated_at")
-            Date ciCreatedAt
+            Profile profile
     ) {
         public record Profile(
-                //닉네임
                 @JsonProperty("nickname")
                 String nickName,
-
-                //프로필 미리보기 이미지
-                @JsonProperty("thumbnail_image_url")
-                String thumbnailImageUrl,
-
-                //프로필 사진 URL
-                @JsonProperty("profile_image_url")
-                String profileImageUrl,
-
-                //프로필 사진 URL 기본 프로필인지 여부
-                //true : 기본 프로필, false : 사용자 등록
-                @JsonProperty("is_default_image")
-                String isDefaultImage,
-
-                //닉네임이 기본 닉네임인지 여부
-                //true : 기본 닉네임, false : 사용자 등록
                 @JsonProperty("is_default_nickname")
                 Boolean isDefaultNickName
         ){ }
     }
 
     public record Partner(
-            //고유 ID
             @JsonProperty("uuid")
             String uuid
     ) {}

--- a/src/main/java/io/github/bunmo/auth/dto/response/TokenResponse.java
+++ b/src/main/java/io/github/bunmo/auth/dto/response/TokenResponse.java
@@ -1,0 +1,9 @@
+package io.github.bunmo.auth.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken,
+        Long expiresIn,
+        boolean isNewMember
+) {
+}

--- a/src/main/java/io/github/bunmo/auth/exception/OAuthErrorCode.java
+++ b/src/main/java/io/github/bunmo/auth/exception/OAuthErrorCode.java
@@ -1,0 +1,38 @@
+package io.github.bunmo.auth.exception;
+
+import io.github.bunmo.auth.service.KakaoOAuthService;
+import io.github.bunmo.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthErrorCode implements ErrorCode {
+    KAKAO_USER_INFO_REQUEST_FAILED(BAD_GATEWAY, "OAUTH_001", "카카오 사용자 정보 요청에 실패했습니다"),
+    INVALID_MEMBER(FORBIDDEN, "OAUTH_002", "유효하지 않은 사용자 입니다"),
+    KAKAO_INVALID_PARAMETER(BAD_REQUEST, "OAUTH_003", "유효하지 않은 파라미터에 의해 카카오인증에 실패했습니다"),
+    KAKAO_SERVER_ERROR(INTERNAL_SERVER_ERROR, "OAUTH_004", "카카오 서버 에러입니다")
+    ;
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus statusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/io/github/bunmo/auth/infrastructure/domain/SocialAccount.java
+++ b/src/main/java/io/github/bunmo/auth/infrastructure/domain/SocialAccount.java
@@ -1,0 +1,37 @@
+package io.github.bunmo.auth.infrastructure.domain;
+
+import io.github.bunmo.auth.infrastructure.domain.enums.Provider;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "social_account")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Provider provider;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    private SocialAccount(Long memberId, Provider provider, String providerId) {
+        this.memberId = memberId;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
+
+    public static SocialAccount create(Long memberId, Provider provider, String providerId) {
+        return new SocialAccount(memberId, provider, providerId);
+    }
+}

--- a/src/main/java/io/github/bunmo/auth/infrastructure/domain/SocialAccount.java
+++ b/src/main/java/io/github/bunmo/auth/infrastructure/domain/SocialAccount.java
@@ -16,7 +16,7 @@ public class SocialAccount {
     private Long id;
 
     @Column(name = "member_id", nullable = false)
-    Long memberId;
+    private Long memberId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/io/github/bunmo/auth/infrastructure/domain/enums/Provider.java
+++ b/src/main/java/io/github/bunmo/auth/infrastructure/domain/enums/Provider.java
@@ -1,0 +1,5 @@
+package io.github.bunmo.auth.infrastructure.domain.enums;
+
+public enum Provider {
+    KAKAO, APPLE
+}

--- a/src/main/java/io/github/bunmo/auth/infrastructure/repository/SocialAccountRepository.java
+++ b/src/main/java/io/github/bunmo/auth/infrastructure/repository/SocialAccountRepository.java
@@ -1,0 +1,11 @@
+package io.github.bunmo.auth.infrastructure.repository;
+
+import io.github.bunmo.auth.infrastructure.domain.SocialAccount;
+import io.github.bunmo.auth.infrastructure.domain.enums.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+    Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
+}

--- a/src/main/java/io/github/bunmo/auth/infrastructure/repository/SocialAccountRepository.java
+++ b/src/main/java/io/github/bunmo/auth/infrastructure/repository/SocialAccountRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
     Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
+
+    String provider(Provider provider);
 }

--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -39,7 +39,7 @@ public class AuthService {
         KakaoUserInfoResponse userInfo = kakaoOAuthService.getUserInfo(kakaoToken.accessToken());
         Long providerId = extractProviderId(userInfo);
 
-        Member member = findOrCreateMember(providerId);
+        Member member = findOrCreateMember(Provider.KAKAO, providerId);
 
         Authentication auth = createAuthentication(member);
         return new TokenResponse(
@@ -50,8 +50,8 @@ public class AuthService {
         );
     }
 
-    private Member findOrCreateMember(Long providerId) {
-        return socialAccountRepository.findByProviderAndProviderId(Provider.KAKAO, providerId.toString())
+    private Member findOrCreateMember(Provider provider, Long providerId) {
+        return socialAccountRepository.findByProviderAndProviderId(provider, providerId.toString())
                 .map(this::findAndValidateMember)
                 .orElseGet(() -> createNewMemberWithSocialAccount(providerId));
     }

--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -1,0 +1,83 @@
+package io.github.bunmo.auth.service;
+
+import io.github.bunmo.auth.dto.request.KakaoLoginRequest;
+import io.github.bunmo.auth.dto.response.KakaoTokenResponse;
+import io.github.bunmo.auth.dto.response.KakaoUserInfoResponse;
+import io.github.bunmo.auth.dto.response.TokenResponse;
+import io.github.bunmo.auth.exception.OAuthErrorCode;
+import io.github.bunmo.auth.infrastructure.domain.SocialAccount;
+import io.github.bunmo.auth.infrastructure.domain.enums.Provider;
+import io.github.bunmo.auth.infrastructure.repository.SocialAccountRepository;
+import io.github.bunmo.common.exception.BusinessException;
+import io.github.bunmo.member.exception.MemberErrorCode;
+import io.github.bunmo.member.infrastructure.domain.Member;
+import io.github.bunmo.member.infrastructure.repository.MemberRepository;
+import io.github.bunmo.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final KakaoOAuthService kakaoOAuthService;
+    private final MemberRepository memberRepository;
+    private final SocialAccountRepository socialAccountRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public TokenResponse kakaoLogin(KakaoLoginRequest request) {
+        KakaoTokenResponse kakaoToken = kakaoOAuthService.getAccessTokenFromKakao(request.code());
+        KakaoUserInfoResponse userInfo = kakaoOAuthService.getUserInfo(kakaoToken.accessToken());
+        Long providerId = extractProviderId(userInfo);
+
+        Optional<SocialAccount> existing = socialAccountRepository.findByProviderAndProviderId(Provider.KAKAO, providerId.toString());
+        boolean isNewMember = existing.isEmpty();
+        Member member;
+        if (isNewMember) {
+            member = Member.createPendingMember();
+            memberRepository.save(member);
+
+            SocialAccount socialAccount = SocialAccount.create(member.getId(), Provider.KAKAO, providerId.toString());
+            socialAccountRepository.save(socialAccount);
+        } else {
+            SocialAccount socialAccount = existing.get();
+            member = memberRepository.findById(socialAccount.getMemberId())
+                    .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+            if(!member.validateMemberStatus()) {
+                throw new BusinessException(OAuthErrorCode.INVALID_MEMBER);
+            }
+        }
+
+        Authentication auth = createAuthentication(member);
+        return new TokenResponse(
+                jwtUtil.createAccessToken(auth),
+                jwtUtil.createRefreshToken(auth),
+                jwtUtil.getAccessTokenValidity(),
+                member.isNewMember()
+        );
+    }
+
+    private Long extractProviderId(KakaoUserInfoResponse userInfo) {
+        if (userInfo.id() == null) {
+            throw new BusinessException(OAuthErrorCode.KAKAO_USER_INFO_REQUEST_FAILED);
+        }
+        return userInfo.id();
+    }
+
+    private Authentication createAuthentication(Member member) {
+        return new UsernamePasswordAuthenticationToken(
+                member.getId(),
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + member.role().name()))
+        );
+    }
+}

--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -53,7 +53,7 @@ public class AuthService {
     private Member findOrCreateMember(Provider provider, Long providerId) {
         return socialAccountRepository.findByProviderAndProviderId(provider, providerId.toString())
                 .map(this::findAndValidateMember)
-                .orElseGet(() -> createNewMemberWithSocialAccount(providerId));
+                .orElseGet(() -> createNewMemberWithSocialAccount(provider, providerId));
     }
 
     private Member findAndValidateMember(SocialAccount socialAccount) {
@@ -67,11 +67,11 @@ public class AuthService {
         return member;
     }
 
-    private Member createNewMemberWithSocialAccount(Long providerId) {
+    private Member createNewMemberWithSocialAccount(Provider provider, Long providerId) {
         Member member = Member.createPendingMember();
         memberRepository.save(member);
 
-        SocialAccount socialAccount = SocialAccount.create(member.getId(), Provider.KAKAO, providerId.toString());
+        SocialAccount socialAccount = SocialAccount.create(member.getId(), provider, providerId.toString());
         socialAccountRepository.save(socialAccount);
         return member;
     }

--- a/src/main/java/io/github/bunmo/auth/service/KakaoOAuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/KakaoOAuthService.java
@@ -1,0 +1,60 @@
+package io.github.bunmo.auth.service;
+
+import io.github.bunmo.auth.config.KakaoOAuthProperties;
+import io.github.bunmo.auth.dto.response.KakaoTokenResponse;
+import io.github.bunmo.auth.dto.response.KakaoUserInfoResponse;
+import io.github.bunmo.auth.exception.OAuthErrorCode;
+import io.github.bunmo.common.exception.BusinessException;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+    private final KakaoOAuthProperties properties;
+
+    public KakaoTokenResponse getAccessTokenFromKakao(String code) {
+
+        KakaoTokenResponse kakaoTokenResponseDto = WebClient.create(properties.tokenUri()).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path(properties.tokenPath())
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", properties.clientId())
+                        .queryParam("client_secret", properties.clientSecret())
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new BusinessException(OAuthErrorCode.KAKAO_INVALID_PARAMETER)))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new BusinessException(OAuthErrorCode.KAKAO_SERVER_ERROR)))
+                .bodyToMono(KakaoTokenResponse.class)
+                .block();
+        return kakaoTokenResponseDto;
+    }
+
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+
+        KakaoUserInfoResponse userInfo = WebClient.create(properties.userInfoUri())
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path(properties.userInfoPath())
+                        .build(true))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new BusinessException(OAuthErrorCode.KAKAO_INVALID_PARAMETER)))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new BusinessException(OAuthErrorCode.KAKAO_SERVER_ERROR)))
+                .bodyToMono(KakaoUserInfoResponse.class)
+                .block();
+
+        return userInfo;
+    }
+}

--- a/src/main/java/io/github/bunmo/auth/service/KakaoOAuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/KakaoOAuthService.java
@@ -21,7 +21,7 @@ public class KakaoOAuthService {
 
     public KakaoTokenResponse getAccessTokenFromKakao(String code) {
 
-        KakaoTokenResponse kakaoTokenResponseDto = WebClient.create(properties.tokenUri()).post()
+        return WebClient.create(properties.tokenUri()).post()
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
                         .path(properties.tokenPath())
@@ -36,12 +36,11 @@ public class KakaoOAuthService {
                 .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new BusinessException(OAuthErrorCode.KAKAO_SERVER_ERROR)))
                 .bodyToMono(KakaoTokenResponse.class)
                 .block();
-        return kakaoTokenResponseDto;
     }
 
     public KakaoUserInfoResponse getUserInfo(String accessToken) {
 
-        KakaoUserInfoResponse userInfo = WebClient.create(properties.userInfoUri())
+        return WebClient.create(properties.userInfoUri())
                 .get()
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
@@ -54,7 +53,5 @@ public class KakaoOAuthService {
                 .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new BusinessException(OAuthErrorCode.KAKAO_SERVER_ERROR)))
                 .bodyToMono(KakaoUserInfoResponse.class)
                 .block();
-
-        return userInfo;
     }
 }

--- a/src/main/java/io/github/bunmo/member/exception/MemberErrorCode.java
+++ b/src/main/java/io/github/bunmo/member/exception/MemberErrorCode.java
@@ -1,0 +1,35 @@
+package io.github.bunmo.member.exception;
+
+import io.github.bunmo.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public enum MemberErrorCode implements ErrorCode {
+    MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다");
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    MemberErrorCode(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
@@ -1,33 +1,31 @@
 package io.github.bunmo.member.infrastructure.domain;
 
 import io.github.bunmo.member.infrastructure.domain.enums.ActiveType;
-import io.github.bunmo.member.infrastructure.domain.enums.AuthType;
 import io.github.bunmo.member.infrastructure.domain.enums.RoleType;
 import io.github.bunmo.member.infrastructure.domain.vo.MemberLocation;
 import io.github.bunmo.member.infrastructure.domain.vo.MemberProfile;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Entity
 @Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String email;
-
     @Embedded
     private MemberProfile memberProfile;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "auth_type", nullable = false)
-    private AuthType authType;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "active_type", nullable = false)
@@ -50,11 +48,38 @@ public class Member {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public String email() {
-        return this.email;
+    public static Member createPendingMember() {
+        Member member = new Member();
+        member.activeType = ActiveType.PENDING;
+        member.role = RoleType.MEMBER;
+        member.location = null;
+        member.gatheringOpenCount = 0;
+        return member;
+    }
+
+    public void completeOnboarding(MemberProfile memberProfile) {
+        this.memberProfile = memberProfile;
+        this.activeType = ActiveType.ACTIVE;
     }
 
     public RoleType role() {
         return this.role;
+    }
+
+    public boolean validateMemberStatus() {
+        if (activeType == ActiveType.BANNED) {
+            return false;
+        }
+        if (activeType == ActiveType.WITHDRAWAL) {
+            return false;
+        }
+        if (activeType == ActiveType.INACTIVE) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isNewMember() {
+        return activeType == ActiveType.PENDING;
     }
 }

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
@@ -67,16 +67,7 @@ public class Member {
     }
 
     public boolean validateMemberStatus() {
-        if (activeType == ActiveType.BANNED) {
-            return false;
-        }
-        if (activeType == ActiveType.WITHDRAWAL) {
-            return false;
-        }
-        if (activeType == ActiveType.INACTIVE) {
-            return false;
-        }
-        return true;
+        return activeType.isValid();
     }
 
     public boolean isNewMember() {

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/ActiveType.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/ActiveType.java
@@ -1,5 +1,5 @@
 package io.github.bunmo.member.infrastructure.domain.enums;
 
 public enum ActiveType {
-    ACTIVE, INACTIVE, BANNED, WITHDRAWAL
+    PENDING, ACTIVE, INACTIVE, BANNED, WITHDRAWAL
 }

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/ActiveType.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/enums/ActiveType.java
@@ -1,5 +1,9 @@
 package io.github.bunmo.member.infrastructure.domain.enums;
 
 public enum ActiveType {
-    PENDING, ACTIVE, INACTIVE, BANNED, WITHDRAWAL
+    PENDING, ACTIVE, INACTIVE, BANNED, WITHDRAWAL;
+
+    public boolean isValid() {
+        return this == ACTIVE || this == PENDING;
+    }
 }

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/vo/MemberLocation.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/vo/MemberLocation.java
@@ -7,11 +7,10 @@ import java.math.BigDecimal;
 
 @Embeddable
 public record MemberLocation(
-        @Column(nullable = false, precision = 17, scale = 14)
+        @Column(precision = 17, scale = 14)
         BigDecimal x,
-        @Column(nullable = false, precision = 16, scale = 14)
+        @Column(precision = 16, scale = 14)
         BigDecimal y,
-        @Column(nullable = false)
         String address
 ) {
 }

--- a/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/io/github/bunmo/security/CustomUserDetails.java
+++ b/src/main/java/io/github/bunmo/security/CustomUserDetails.java
@@ -12,16 +12,16 @@ import java.util.List;
 
 @Getter
 public class CustomUserDetails implements UserDetails {
-    private String email;
+    private Long id;
     private RoleType role;
 
-    private CustomUserDetails(String email, RoleType role) {
-        this.email = email;
+    private CustomUserDetails(Long id, RoleType role) {
+        this.id = id;
         this.role = role;
     }
 
     public static CustomUserDetails from(Member member) {
-        return new CustomUserDetails(member.email(), member.role());
+        return new CustomUserDetails(member.getId(), member.role());
     }
 
     @Override
@@ -36,6 +36,6 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return email;
+        return id.toString();
     }
 }

--- a/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         return request -> {
             CorsConfiguration configuration = new CorsConfiguration();
-            configuration.setAllowedOrigins(Collections.singletonList("http://localhost:6004"));
+            configuration.setAllowedOrigins(Arrays.asList("http://localhost:6004"));
             configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
             configuration.setAllowCredentials(true);
             configuration.setAllowedHeaders(Collections.singletonList("*"));
@@ -65,7 +65,13 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/member/login", "/api/v1/member/signup", "/api-docs/**", "/swagger-ui/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers(
+                                "/api/v1/member/login",
+                                "/api/v1/member/signup",
+                                "/api/v1/oauth2/kakao",
+                                "/api-docs/**",
+                                "/swagger-ui/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
+++ b/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
@@ -19,8 +19,8 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(email)
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Member member = memberRepository.findById(Long.parseLong(id))
                 .orElseThrow(() -> new AuthException(AuthErrorCode.ACCESS_DENIED));
 
         return CustomUserDetails.from(member);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,7 +22,7 @@ jwt:
 
 oauth2:
   kakao:
-    client-id: kakao-client-id
+    client-id: kakao-client-id-test
     client-secret: kakao-secret
     redirect-uri: http://localhost:18080/api/v1/oauth2/kakao
     token-uri: https://kauth.kakao.com

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,3 +19,13 @@ jwt:
     expire-time: 86400000
   refresh-token:
     expire-time: 259200000
+
+oauth2:
+  kakao:
+    client-id: kakao-client-id
+    client-secret: kakao-secret
+    redirect-uri: http://localhost:18080/api/v1/oauth2/kakao
+    token-uri: https://kauth.kakao.com
+    token-path: /oauth/token
+    user-info-uri: https://kapi.kakao.com
+    user-info-path: /v2/user/me

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:23306/bunmo?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: bunmo_user
+    password: bunmo_password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    hibernate:
+      ddl-auto: update
+
+jwt:
+  secret: +911VYr4eRTnV4Ubb2i/GhmQjs9CCPnfVhxdXe/sX0l6rO4budtCOK4xCFUbspeiplwjZCotXsYsKGKi0DlIKw==
+  access-token:
+    expire-time: 86400000
+  refresh-token:
+    expire-time: 259200000

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,7 +22,7 @@ jwt:
 
 oauth2:
   kakao:
-    client-id: kakao-client-id-test
+    client-id: kakao-client-id
     client-secret: kakao-secret
     redirect-uri: http://localhost:18080/api/v1/oauth2/kakao
     token-uri: https://kauth.kakao.com

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+    hibernate:
+      ddl-auto: validate
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token:
+    expire-time: ${JWT_ACCESS_TOKEN_EXPIRE_TIME:86400000}
+  refresh-token:
+    expire-time: ${JWT_REFRESH_TOKEN_EXPIRE_TIME:259200000}
+
+oauth2:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+    token-uri: https://kauth.kakao.com
+    token-path: /oauth/token
+    user-info-uri: https://kapi.kakao.com
+    user-info-path: /v2/user/me

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,19 +1,9 @@
 spring:
   application:
     name: bunmo
-  datasource:
-    url: jdbc:mysql://localhost:23306/lxp?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: bunmo_user
-    password: bunmo_password
-    driver-class-name: com.mysql.cj.jdbc.Driver
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}
 
-  jpa:
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
-    hibernate:
-      ddl-auto: update
 server:
   port: 18080
 
@@ -28,10 +18,3 @@ springdoc:
     operations-sorter: method
     tags-sorter: alpha
     doc-expansion: none
-
-jwt:
-  secret: +911VYr4eRTnV4Ubb2i/GhmQjs9CCPnfVhxdXe/sX0l6rO4budtCOK4xCFUbspeiplwjZCotXsYsKGKi0DlIKw==
-  access-token:
-    expire-time: 86400000
-  refresh-token:
-    expire-time: 259200000


### PR DESCRIPTION
# 연관된 이슈
- close #10 

# 작업 내용
- 카카오 로그인 인증 구현

# 리뷰 요구사항(선택)
- 카카오 OAuth2 인증에 필요한 키 값을 노출하지 않기 위해 application 파일을 dev와 prod로 나누었습니다. application-dev.yml, application-prod.yml 은 노션에 정리해 두었습니다 

# 참고 사항
- 카카오 로그인의 응답값은 아래 문서 참고
https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#profile
