### PR TITLE
[REFACTOR] JWT 토큰 식별자를 memberId에서 UUID로 변경

### DIFF
--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import io.github.bunmo.common.exception.BusinessException;
 import io.github.bunmo.member.exception.MemberErrorCode;
 import io.github.bunmo.member.infrastructure.domain.Member;
 import io.github.bunmo.member.infrastructure.repository.MemberRepository;
+import io.github.bunmo.security.CustomUserDetails;
 import io.github.bunmo.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -84,9 +85,9 @@ public class AuthService {
 
     private Authentication createAuthentication(Member member) {
         return new UsernamePasswordAuthenticationToken(
-                member.getId(),
-                null,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + member.role().name()))
+            CustomUserDetails.from(member),
+            null,
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + member.role().name()))
         );
     }
 }

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
@@ -25,7 +25,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true, updatable = false)
     private String uuid;
 
     @Embedded

--- a/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/domain/Member.java
@@ -5,6 +5,7 @@ import io.github.bunmo.member.infrastructure.domain.enums.RoleType;
 import io.github.bunmo.member.infrastructure.domain.vo.MemberLocation;
 import io.github.bunmo.member.infrastructure.domain.vo.MemberProfile;
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +24,9 @@ public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String uuid;
 
     @Embedded
     private MemberProfile memberProfile;
@@ -50,6 +54,7 @@ public class Member {
 
     public static Member createPendingMember() {
         Member member = new Member();
+        member.uuid = UUID.randomUUID().toString();
         member.activeType = ActiveType.PENDING;
         member.role = RoleType.MEMBER;
         member.location = null;

--- a/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package io.github.bunmo.member.infrastructure.repository;
 
 import io.github.bunmo.member.infrastructure.domain.Member;
+import javax.swing.text.html.Option;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUuid(String uuid);
 }

--- a/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/io/github/bunmo/member/infrastructure/repository/MemberRepository.java
@@ -1,7 +1,6 @@
 package io.github.bunmo.member.infrastructure.repository;
 
 import io.github.bunmo.member.infrastructure.domain.Member;
-import javax.swing.text.html.Option;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/io/github/bunmo/security/CustomUserDetails.java
+++ b/src/main/java/io/github/bunmo/security/CustomUserDetails.java
@@ -12,16 +12,16 @@ import java.util.List;
 
 @Getter
 public class CustomUserDetails implements UserDetails {
-    private Long id;
+    private String uuid;
     private RoleType role;
 
-    private CustomUserDetails(Long id, RoleType role) {
-        this.id = id;
+    private CustomUserDetails(String uuid, RoleType role) {
+        this.uuid = uuid;
         this.role = role;
     }
 
     public static CustomUserDetails from(Member member) {
-        return new CustomUserDetails(member.getId(), member.role());
+        return new CustomUserDetails(member.getUuid(), member.role());
     }
 
     @Override
@@ -36,6 +36,6 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return id.toString();
+        return uuid;
     }
 }

--- a/src/main/java/io/github/bunmo/security/JwtFilter.java
+++ b/src/main/java/io/github/bunmo/security/JwtFilter.java
@@ -35,8 +35,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) {
             try {
-                String email = jwtUtil.getSubject(token);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                String uuid = jwtUtil.getSubject(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(uuid);
                 Authentication authentication = new UsernamePasswordAuthenticationToken(
                         userDetails,
                         token,

--- a/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
+++ b/src/main/java/io/github/bunmo/security/service/CustomUserDetailsService.java
@@ -19,8 +19,8 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        Member member = memberRepository.findById(Long.parseLong(id))
+    public UserDetails loadUserByUsername(String uuid) throws UsernameNotFoundException {
+        Member member = memberRepository.findByUuid(uuid)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.ACCESS_DENIED));
 
         return CustomUserDetails.from(member);


### PR DESCRIPTION
# 연관된 이슈
- close #15

# 작업 내용
 - Member 엔티티에 UUID 필드 추가                                                                                                                                                                                                 
 - JWT 토큰 subject를 memberId에서 UUID로 변경                                                                                                                                                                                    
 - CustomUserDetails에서 id 대신 uuid를 식별자로 사용                                                                                                                                                                             
 - CustomUserDetailsService에서 uuid 기반 회원 조회로 변경                                                                                                                                                                        
 - MemberRepository에 findByUuid() 메소드 추가    

# 리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요
