### PR TITLE
[FEAT] jwt 토큰 재발급 api

### DIFF
--- a/src/main/java/io/github/bunmo/auth/controller/AuthController.java
+++ b/src/main/java/io/github/bunmo/auth/controller/AuthController.java
@@ -35,6 +35,7 @@ public class AuthController implements AuthControllerDoc {
                 .body(ApiResponse.success(resultCode, response));
     }
 
+    @Override
     @PostMapping("/auth/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> reissueToken(
         @RequestBody TokenReissueRequest request

--- a/src/main/java/io/github/bunmo/auth/controller/AuthController.java
+++ b/src/main/java/io/github/bunmo/auth/controller/AuthController.java
@@ -4,8 +4,11 @@ import io.github.bunmo.auth.controller.doc.AuthControllerDoc;
 import io.github.bunmo.auth.dto.AuthResultCode;
 import io.github.bunmo.auth.dto.request.KakaoLoginRequest;
 import io.github.bunmo.auth.dto.response.LoginResponse;
+import io.github.bunmo.auth.dto.response.TokenResponse;
 import io.github.bunmo.auth.service.AuthService;
 import io.github.bunmo.common.web.ApiResponse;
+import io.github.bunmo.security.CustomUserDetails;
+import io.github.bunmo.security.annotation.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,5 +34,14 @@ public class AuthController implements AuthControllerDoc {
                 : AuthResultCode.LOGIN_SUCCESS;
         return ResponseEntity.status(resultCode.statusCode())
                 .body(ApiResponse.success(resultCode, response));
+    }
+
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> reissueToken(
+        @LoginUser CustomUserDetails user
+    ) {
+        TokenResponse response = authService.reissueToken(user);
+        return ResponseEntity.status(AuthResultCode.JWT_TOKEN_REISSUE_SUCCESS.statusCode())
+            .body(ApiResponse.success(AuthResultCode.JWT_TOKEN_REISSUE_SUCCESS, response));
     }
 }

--- a/src/main/java/io/github/bunmo/auth/controller/AuthController.java
+++ b/src/main/java/io/github/bunmo/auth/controller/AuthController.java
@@ -3,12 +3,11 @@ package io.github.bunmo.auth.controller;
 import io.github.bunmo.auth.controller.doc.AuthControllerDoc;
 import io.github.bunmo.auth.dto.AuthResultCode;
 import io.github.bunmo.auth.dto.request.KakaoLoginRequest;
+import io.github.bunmo.auth.dto.request.TokenReissueRequest;
 import io.github.bunmo.auth.dto.response.LoginResponse;
 import io.github.bunmo.auth.dto.response.TokenResponse;
 import io.github.bunmo.auth.service.AuthService;
 import io.github.bunmo.common.web.ApiResponse;
-import io.github.bunmo.security.CustomUserDetails;
-import io.github.bunmo.security.annotation.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,9 +37,9 @@ public class AuthController implements AuthControllerDoc {
 
     @PostMapping("/auth/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> reissueToken(
-        @LoginUser CustomUserDetails user
+        @RequestBody TokenReissueRequest request
     ) {
-        TokenResponse response = authService.reissueToken(user);
+        TokenResponse response = authService.reissueToken(request);
         return ResponseEntity.status(AuthResultCode.JWT_TOKEN_REISSUE_SUCCESS.statusCode())
             .body(ApiResponse.success(AuthResultCode.JWT_TOKEN_REISSUE_SUCCESS, response));
     }

--- a/src/main/java/io/github/bunmo/auth/controller/AuthController.java
+++ b/src/main/java/io/github/bunmo/auth/controller/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController implements AuthControllerDoc {
     @Override
     @PostMapping("/auth/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> reissueToken(
-        @RequestBody TokenReissueRequest request
+        @Valid @RequestBody TokenReissueRequest request
     ) {
         TokenResponse response = authService.reissueToken(request);
         return ResponseEntity.status(AuthResultCode.JWT_TOKEN_REISSUE_SUCCESS.statusCode())

--- a/src/main/java/io/github/bunmo/auth/controller/doc/AuthControllerDoc.java
+++ b/src/main/java/io/github/bunmo/auth/controller/doc/AuthControllerDoc.java
@@ -1,7 +1,9 @@
 package io.github.bunmo.auth.controller.doc;
 
 import io.github.bunmo.auth.dto.request.KakaoLoginRequest;
+import io.github.bunmo.auth.dto.request.TokenReissueRequest;
 import io.github.bunmo.auth.dto.response.LoginResponse;
+import io.github.bunmo.auth.dto.response.TokenResponse;
 import io.github.bunmo.common.web.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -144,5 +146,83 @@ public interface AuthControllerDoc {
     )
     ResponseEntity<ApiResponse<LoginResponse>> kakaoLogin(
             KakaoLoginRequest request
+    );
+
+    @Operation(
+        summary = "jwt token 재발급",
+        description = "refresh token으로 jwt token을 재발급 합니다",
+        responses = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "토큰 재발급 성공",
+                content = @Content(
+                    schema = @Schema(implementation = TokenResponse.class),
+                    examples = @ExampleObject(
+                        name = "LOGIN_SUCCESS",
+                        value = """
+                            {
+                              "code": "AUTH_003",
+                              "message": "토큰 재발급 성공",
+                              "data": {
+                                "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI3YWIyZTk2NC0wNDZkLTQxNWMtOWQxNi0yMGNlNWI3ODE0NGUiLCJyb2xlcyI6IlJPTEVfTUVNQkVSIiwiaWF0IjoxNzcxMjMyMDk1LCJleHAiOjE3NzEzMTg0OTV9.fPbNmAZX1kBqGYSj9FxAFGjp8BN5gul0D9sjQMHxV3lp1q_JGeqLnA8u1oWCJi6NqeUT4AMziQtdRWwOiwMEbg",
+                                "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiI3YWIyZTk2NC0wNDZkLTQxNWMtOWQxNi0yMGNlNWI3ODE0NGUiLCJyb2xlcyI6IlJPTEVfTUVNQkVSIiwiaWF0IjoxNzcxMjMyMDk1LCJleHAiOjE3NzE0OTEyOTV9.AsHVQsQFs84DUYAOH4GZs61CuBa0qq7_1sConU7sMYC5DF6RWuLlXSkv0_NNWQC9qaZTf3gNCA_Q-JvU7tNbaQ"
+                              }
+                            }
+                                                    """
+                    )
+                )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "유효하지 않은 jwt token",
+                content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                        name = "INVALID_JWT_TOKEN",
+                        value = """
+                                                    {
+                                                      "code": "UNAUTHORIZED_001",
+                                                      "message": "유효하지 않은 토큰입니다"
+                                                    }
+                                                    """
+                    )
+                )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 회원",
+                content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                        name = "MEMBER_NOT_FOUND",
+                        value = """
+                                                    {
+                                                      "code": "MEMBER_001",
+                                                      "message": "존재하지 않는 회원입니다"
+                                                    }
+                                                    """
+                    )
+                )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "유효하지 않은 회원",
+                content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                        name = "MEMBER_INVALID_STATUS",
+                        value = """
+                                                    {
+                                                      "code": "MEMBER_002",
+                                                      "message": "유효하지 않은 회원 상태입니다"
+                                                    }
+                                                    """
+                    )
+                )
+            ),
+        }
+    )
+    ResponseEntity<ApiResponse<TokenResponse>> reissueToken(
+        TokenReissueRequest request
     );
 }

--- a/src/main/java/io/github/bunmo/auth/controller/doc/AuthControllerDoc.java
+++ b/src/main/java/io/github/bunmo/auth/controller/doc/AuthControllerDoc.java
@@ -220,6 +220,22 @@ public interface AuthControllerDoc {
                     )
                 )
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 토큰 타입",
+                content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                        name = "INVALID_TOKEN_TYPE",
+                        value = """
+                            {
+                                "code": "UNAUTHORIZED_006",
+                                "message": "잘못된 토큰 타입입니다."
+                            }
+                        """
+                    )
+                )
+            ),
         }
     )
     ResponseEntity<ApiResponse<TokenResponse>> reissueToken(

--- a/src/main/java/io/github/bunmo/auth/dto/AuthResultCode.java
+++ b/src/main/java/io/github/bunmo/auth/dto/AuthResultCode.java
@@ -12,7 +12,8 @@ import static org.springframework.http.HttpStatus.OK;
 @RequiredArgsConstructor
 public enum AuthResultCode implements ResultCode {
     LOGIN_SUCCESS(OK, "AUTH_001", "로그인 성공"),
-    SIGNUP_SUCCESS(CREATED, "AUTH_002", "회원가입 성공");
+    SIGNUP_SUCCESS(CREATED, "AUTH_002", "회원가입 성공"),
+    JWT_TOKEN_REISSUE_SUCCESS(OK, "AUTH_003", "토큰 재발급 성공");
 
     private final HttpStatus statusCode;
     private final String code;

--- a/src/main/java/io/github/bunmo/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/io/github/bunmo/auth/dto/request/TokenReissueRequest.java
@@ -1,6 +1,16 @@
 package io.github.bunmo.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(name = "jwt token 재발급 요청", description = "jwt token 재발급 요청")
 public record TokenReissueRequest(
+    @Schema(
+        description = "refresh token",
+        example = "로그인 후 전달 받은 refreshToken",
+        type = "string"
+    )
+    @NotBlank(message = "refreshToken은 필수입니다")
     String refreshToken
 ) {
 

--- a/src/main/java/io/github/bunmo/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/io/github/bunmo/auth/dto/request/TokenReissueRequest.java
@@ -1,0 +1,7 @@
+package io.github.bunmo.auth.dto.request;
+
+public record TokenReissueRequest(
+    String refreshToken
+) {
+
+}

--- a/src/main/java/io/github/bunmo/auth/dto/response/TokenResponse.java
+++ b/src/main/java/io/github/bunmo/auth/dto/response/TokenResponse.java
@@ -1,0 +1,13 @@
+package io.github.bunmo.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "엑세스 토큰 재발급 응답", description = "엑세스 토큰 응답 정보")
+public record TokenResponse(
+    @Schema(description = "액세스 토큰", example = "eyJhbGci...")
+    String accessToken,
+    @Schema(description = "리프레시 토큰", example = "eyJhbGci...")
+    String refreshToken
+) {
+
+}

--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import io.github.bunmo.auth.dto.request.KakaoLoginRequest;
 import io.github.bunmo.auth.dto.response.KakaoTokenResponse;
 import io.github.bunmo.auth.dto.response.KakaoUserInfoResponse;
 import io.github.bunmo.auth.dto.response.LoginResponse;
+import io.github.bunmo.auth.dto.response.TokenResponse;
 import io.github.bunmo.auth.exception.OAuthErrorCode;
 import io.github.bunmo.auth.infrastructure.domain.SocialAccount;
 import io.github.bunmo.auth.infrastructure.domain.enums.Provider;
@@ -48,6 +49,14 @@ public class AuthService {
                 jwtUtil.getAccessTokenValidity(),
                 member.isNewMember()
         );
+    }
+
+    public TokenResponse reissueToken(CustomUserDetails user) {
+        Member member = memberRepository.findByUuid(user.getUuid())
+            .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Authentication auth = createAuthentication(member);
+        return new TokenResponse(jwtUtil.createAccessToken(auth), jwtUtil.createRefreshToken(auth));
     }
 
     private Member findOrCreateMember(Provider provider, Long providerId) {

--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -16,8 +16,8 @@ import io.github.bunmo.member.infrastructure.domain.Member;
 import io.github.bunmo.member.infrastructure.repository.MemberRepository;
 import io.github.bunmo.security.CustomUserDetails;
 import io.github.bunmo.security.exception.AuthErrorCode;
-import io.github.bunmo.security.exception.AuthException;
 import io.github.bunmo.security.jwt.JwtUtil;
+import io.github.bunmo.security.jwt.TokenType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -56,8 +56,13 @@ public class AuthService {
 
     public TokenResponse reissueToken(TokenReissueRequest request) {
         String refreshToken = request.refreshToken();
+
+        if (jwtUtil.getTokenType(refreshToken) != TokenType.REFRESH_TOKEN) {
+            throw new BusinessException(AuthErrorCode.INVALID_TOKEN_TYPE);
+        }
+
         if (!jwtUtil.validateToken(refreshToken)) {
-            throw new AuthException(AuthErrorCode.INVALID_JWT_TOKEN);
+            throw new BusinessException(AuthErrorCode.INVALID_JWT_TOKEN);
         }
 
         String uuid = jwtUtil.getUuid(refreshToken);

--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -64,6 +64,10 @@ public class AuthService {
         Member member = memberRepository.findByUuid(uuid)
             .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
+        if (!member.validateMemberStatus()) {
+            throw new BusinessException(MemberErrorCode.MEMBER_INVALID_STATUS);
+        }
+
         Authentication auth = createAuthentication(member);
         return new TokenResponse(jwtUtil.createAccessToken(auth), jwtUtil.createRefreshToken(auth));
     }

--- a/src/main/java/io/github/bunmo/auth/service/AuthService.java
+++ b/src/main/java/io/github/bunmo/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package io.github.bunmo.auth.service;
 
 import io.github.bunmo.auth.dto.request.KakaoLoginRequest;
+import io.github.bunmo.auth.dto.request.TokenReissueRequest;
 import io.github.bunmo.auth.dto.response.KakaoTokenResponse;
 import io.github.bunmo.auth.dto.response.KakaoUserInfoResponse;
 import io.github.bunmo.auth.dto.response.LoginResponse;
@@ -14,6 +15,8 @@ import io.github.bunmo.member.exception.MemberErrorCode;
 import io.github.bunmo.member.infrastructure.domain.Member;
 import io.github.bunmo.member.infrastructure.repository.MemberRepository;
 import io.github.bunmo.security.CustomUserDetails;
+import io.github.bunmo.security.exception.AuthErrorCode;
+import io.github.bunmo.security.exception.AuthException;
 import io.github.bunmo.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,8 +54,14 @@ public class AuthService {
         );
     }
 
-    public TokenResponse reissueToken(CustomUserDetails user) {
-        Member member = memberRepository.findByUuid(user.getUuid())
+    public TokenResponse reissueToken(TokenReissueRequest request) {
+        String refreshToken = request.refreshToken();
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new AuthException(AuthErrorCode.INVALID_JWT_TOKEN);
+        }
+
+        String uuid = jwtUtil.getUuid(refreshToken);
+        Member member = memberRepository.findByUuid(uuid)
             .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Authentication auth = createAuthentication(member);

--- a/src/main/java/io/github/bunmo/common/config/WebConfig.java
+++ b/src/main/java/io/github/bunmo/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package io.github.bunmo.common.config;
+
+import io.github.bunmo.security.annotation.LoginUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/io/github/bunmo/member/exception/MemberErrorCode.java
+++ b/src/main/java/io/github/bunmo/member/exception/MemberErrorCode.java
@@ -3,10 +3,12 @@ package io.github.bunmo.member.exception;
 import io.github.bunmo.common.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 public enum MemberErrorCode implements ErrorCode {
-    MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다");
+    MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다"),
+    MEMBER_INVALID_STATUS(FORBIDDEN, "MEMBER_002", "유효하지 않은 회원 상태입니다");
 
     private final HttpStatus statusCode;
     private final String code;

--- a/src/main/java/io/github/bunmo/security/annotation/LoginUser.java
+++ b/src/main/java/io/github/bunmo/security/annotation/LoginUser.java
@@ -1,0 +1,12 @@
+package io.github.bunmo.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+
+}

--- a/src/main/java/io/github/bunmo/security/annotation/LoginUserArgumentResolver.java
+++ b/src/main/java/io/github/bunmo/security/annotation/LoginUserArgumentResolver.java
@@ -36,14 +36,10 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
         Object principal = authentication.getPrincipal();
 
-        if (principal instanceof CustomUserDetails) {
-            return principal;
-        }
-
-        if (!(principal instanceof String)) {
+        if (!(principal instanceof CustomUserDetails)) {
             throw new AuthException(AuthErrorCode.UNAUTHORIZED);
         }
-
         return principal;
+
     }
 }

--- a/src/main/java/io/github/bunmo/security/annotation/LoginUserArgumentResolver.java
+++ b/src/main/java/io/github/bunmo/security/annotation/LoginUserArgumentResolver.java
@@ -1,0 +1,49 @@
+package io.github.bunmo.security.annotation;
+
+import io.github.bunmo.security.CustomUserDetails;
+import io.github.bunmo.security.exception.AuthErrorCode;
+import io.github.bunmo.security.exception.AuthException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginUserAnnotation = parameter.hasParameterAnnotation(LoginUser.class);
+        boolean hasUserType = CustomUserDetails.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginUserAnnotation && hasUserType;
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) throws Exception {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null){
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof CustomUserDetails) {
+            return principal;
+        }
+
+        if (!(principal instanceof String)) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        return principal;
+    }
+}

--- a/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/security/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                                 "/api/v1/member/login",
                                 "/api/v1/member/signup",
                                 "/api/v1/oauth2/kakao",
+                                "/api/v1/auth/refresh",
                                 "/api-docs/**",
                                 "/swagger-ui/**"
                         ).permitAll()

--- a/src/main/java/io/github/bunmo/security/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/bunmo/security/exception/AuthErrorCode.java
@@ -9,6 +9,7 @@ public enum AuthErrorCode implements ErrorCode {
     UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_003", "지원하지 않는 토큰입니다"),
     ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_004", "접근이 거부되었습니다"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_005", "인증이 필요합니다"),
+    INVALID_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "UNAUTHORIZED_006", "잘못된 토큰 타입입니다.")
     ;
 
     private final HttpStatus statusCode;

--- a/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
+++ b/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
@@ -27,6 +27,7 @@ public class JwtUtil {
     private final long accessTokenExpireTime;
     private final long refreshTokenExpireTime;
     private static final String AUTHORITIES_KEY = "roles";
+    private static final String TOKEN_TYPE = "type";
 
     public JwtUtil(
             @Value("${jwt.secret}") String secretKey,
@@ -40,11 +41,11 @@ public class JwtUtil {
     }
 
     public String createAccessToken(Authentication authentication) {
-        return generateToken(authentication, accessTokenExpireTime);
+        return generateToken(authentication, accessTokenExpireTime, TokenType.ACCESS_TOKEN.toString());
     }
 
     public String createRefreshToken(Authentication authentication) {
-        return generateToken(authentication, refreshTokenExpireTime);
+        return generateToken(authentication, refreshTokenExpireTime, TokenType.REFRESH_TOKEN.toString());
     }
 
     public Long getAccessTokenValidity() {
@@ -89,7 +90,13 @@ public class JwtUtil {
         return parseClaims(token).getSubject();
     }
 
-    private String generateToken(Authentication authentication, long expireTime) {
+    public TokenType getTokenType(String token) {
+        Claims claims = parseClaims(token);
+        String tokenType = claims.get(TOKEN_TYPE, String.class);
+        return TokenType.valueOf(tokenType);
+    }
+
+    private String generateToken(Authentication authentication, long expireTime, String tokenType) {
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
@@ -100,6 +107,7 @@ public class JwtUtil {
         return Jwts.builder()
                 .subject(authentication.getName())
                 .claim(AUTHORITIES_KEY, authorities)
+                .claim(TOKEN_TYPE, tokenType)
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(key)

--- a/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
+++ b/src/main/java/io/github/bunmo/security/jwt/JwtUtil.java
@@ -85,6 +85,10 @@ public class JwtUtil {
         return parseClaims(token).getSubject();
     }
 
+    public String getUuid(String token) {
+        return parseClaims(token).getSubject();
+    }
+
     private String generateToken(Authentication authentication, long expireTime) {
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)

--- a/src/main/java/io/github/bunmo/security/jwt/TokenType.java
+++ b/src/main/java/io/github/bunmo/security/jwt/TokenType.java
@@ -1,0 +1,5 @@
+package io.github.bunmo.security.jwt;
+
+public enum TokenType {
+    ACCESS_TOKEN, REFRESH_TOKEN
+}


### PR DESCRIPTION
# 연관된 이슈
- close ##18

# 작업 내용
- 로그인한 사용자의 정보를 받아 오는 @LoginUser 추가
- 토큰 재발급 api 추가
- 토큰 재발급 swagger 추가
