### PR TITLE
[FEAT] (gathering):소분모임 생성/목록/상세 조회 API 구현

### DIFF
--- a/db/mysql/init/schema.sql
+++ b/db/mysql/init/schema.sql
@@ -19,13 +19,7 @@ CREATE TABLE `member` (
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 
--- bunmo.product_category definition
-
-CREATE TABLE `product_category` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+-- bunmo.product_category definition (레거시 - gathering 테이블 재설계로 미사용)
 
 
 -- bunmo.reported_user_history definition
@@ -54,19 +48,23 @@ CREATE TABLE `social_account` (
 
 CREATE TABLE `gathering` (
   `id` bigint NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `introduction` varchar(255) NOT NULL,
-  `open_chat_link` varchar(255) NOT NULL,
-  `gathering_time` datetime(6) NOT NULL,
+  `type` enum('ONLINE','MART','FREE') NOT NULL,
+  `active_type` enum('ACTIVE','DELETED','REPORTED','CLOSED') NOT NULL,
+  `category` enum('FOOD','DAILY_SUPPLIES','ELECTRONICS','BEAUTY','BABY','KITCHEN','HOBBY','PET','FASHION','FURNITURE','SPORTS','AUTO','BOOK','OFFICE') NOT NULL,
+  `name` varchar(20) NOT NULL,
+  `introduction` varchar(500) NOT NULL,
+  `open_chat_link` varchar(200) NOT NULL,
+  `price` decimal(10,0) DEFAULT NULL,
+  `product_link` varchar(200) DEFAULT NULL,
+  `meeting_date` date NOT NULL,
+  `meeting_time` time NOT NULL,
   `x` decimal(17,14) NOT NULL,
   `y` decimal(16,14) NOT NULL,
-  `address` varchar(255) NOT NULL,
+  `address` varchar(20) NOT NULL,
   `max_participant_count` int NOT NULL,
-  `owner_id` bigint DEFAULT NULL,
-  `product_category` bigint NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FKc4vg8y04aqb8e74jss5wvnpqo` (`product_category`),
-  CONSTRAINT `FKc4vg8y04aqb8e74jss5wvnpqo` FOREIGN KEY (`product_category`) REFERENCES `product_category` (`id`)
+  `owner_id` bigint NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 

--- a/src/main/java/io/github/bunmo/gathering/controller/GatheringController.java
+++ b/src/main/java/io/github/bunmo/gathering/controller/GatheringController.java
@@ -1,0 +1,55 @@
+package io.github.bunmo.gathering.controller;
+
+import io.github.bunmo.common.web.ApiResponse;
+import io.github.bunmo.gathering.dto.GatheringResultCode;
+import io.github.bunmo.gathering.dto.request.CreateGatheringRequest;
+import io.github.bunmo.gathering.dto.response.CreateGatheringResponse;
+import io.github.bunmo.gathering.dto.response.GatheringDetailResponse;
+import io.github.bunmo.gathering.dto.response.GatheringListPageResponse;
+import io.github.bunmo.gathering.service.GatheringService;
+import io.github.bunmo.security.CustomUserDetails;
+import io.github.bunmo.security.annotation.LoginUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/gatherings")
+@RequiredArgsConstructor
+public class GatheringController {
+
+    private final GatheringService gatheringService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateGatheringResponse>> createGathering(
+            @Valid @RequestBody CreateGatheringRequest request,
+            @LoginUser CustomUserDetails userDetails
+    ) {
+        CreateGatheringResponse response = gatheringService.createGathering(request, userDetails);
+        return ResponseEntity.status(GatheringResultCode.GATHERING_CREATE_SUCCESS.statusCode())
+                .body(ApiResponse.success(GatheringResultCode.GATHERING_CREATE_SUCCESS, response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<GatheringListPageResponse>> getGatherings(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        GatheringListPageResponse response = gatheringService.getGatherings(page, size, date);
+        return ResponseEntity.ok(ApiResponse.success(GatheringResultCode.GATHERING_LIST_SUCCESS, response));
+    }
+
+    @GetMapping("/{gatheringId}")
+    public ResponseEntity<ApiResponse<GatheringDetailResponse>> getGathering(
+            @PathVariable Long gatheringId,
+            @LoginUser CustomUserDetails userDetails
+    ) {
+        GatheringDetailResponse response = gatheringService.getGathering(gatheringId, userDetails);
+        return ResponseEntity.ok(ApiResponse.success(GatheringResultCode.GATHERING_DETAIL_SUCCESS, response));
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/dto/GatheringResultCode.java
+++ b/src/main/java/io/github/bunmo/gathering/dto/GatheringResultCode.java
@@ -1,0 +1,33 @@
+package io.github.bunmo.gathering.dto;
+
+import io.github.bunmo.common.web.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatheringResultCode implements ResultCode {
+    GATHERING_CREATE_SUCCESS(HttpStatus.CREATED, "GATHERING_001", "모임 생성 성공"),
+    GATHERING_LIST_SUCCESS(HttpStatus.OK, "GATHERING_002", "모임 목록 조회 성공"),
+    GATHERING_DETAIL_SUCCESS(HttpStatus.OK, "GATHERING_003", "모임 상세 조회 성공");
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus statusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/dto/request/CreateGatheringRequest.java
+++ b/src/main/java/io/github/bunmo/gathering/dto/request/CreateGatheringRequest.java
@@ -1,0 +1,53 @@
+package io.github.bunmo.gathering.dto.request;
+
+import io.github.bunmo.gathering.infrastructure.domain.enums.CategoryType;
+import io.github.bunmo.gathering.infrastructure.domain.enums.GatheringType;
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CreateGatheringRequest(
+        @NotNull(message = "모임 유형은 필수입니다.")
+        GatheringType type,
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 20, message = "제목은 최대 20자입니다.")
+        String title,
+
+        @DecimalMax(value = "1000000", message = "가격은 100만원 미만이어야 합니다.")
+        @DecimalMin(value = "0", message = "가격은 0 이상이어야 합니다.")
+        BigDecimal price,
+
+        @Size(max = 200, message = "상품 링크는 최대 200자입니다.")
+        String productLink,
+
+        @NotNull(message = "날짜는 필수입니다.")
+        @FutureOrPresent(message = "날짜는 현재 또는 미래여야 합니다.")
+        LocalDate meetingDate,
+
+        @NotNull(message = "시간은 필수입니다.")
+        LocalTime meetingTime,
+
+        @NotBlank(message = "장소는 필수입니다.")
+        @Size(max = 20, message = "장소는 최대 20자입니다.")
+        String location,
+
+        @NotBlank(message = "상세 소개말은 필수입니다.")
+        @Size(max = 500, message = "상세 소개말은 최대 500자입니다.")
+        String description,
+
+        @NotBlank(message = "오픈채팅 링크는 필수입니다.")
+        @Size(max = 200, message = "오픈채팅 링크는 최대 200자입니다.")
+        String openChatLink,
+
+        @NotNull(message = "카테고리는 필수입니다.")
+        CategoryType category,
+
+        @NotNull(message = "최대 인원은 필수입니다.")
+        @Min(value = 2, message = "최대 인원은 2명 이상이어야 합니다.")
+        @Max(value = 8, message = "최대 인원은 8명 이하여야 합니다.")
+        Integer maxParticipants
+) {
+}

--- a/src/main/java/io/github/bunmo/gathering/dto/response/CreateGatheringResponse.java
+++ b/src/main/java/io/github/bunmo/gathering/dto/response/CreateGatheringResponse.java
@@ -1,0 +1,24 @@
+package io.github.bunmo.gathering.dto.response;
+
+import io.github.bunmo.gathering.infrastructure.domain.Gathering;
+import io.github.bunmo.gathering.infrastructure.domain.enums.GatheringType;
+
+import java.time.LocalDateTime;
+
+public record CreateGatheringResponse(
+        Long id,
+        GatheringType type,
+        String title,
+        Long hostId,
+        LocalDateTime createdAt
+) {
+    public static CreateGatheringResponse from(Gathering gathering) {
+        return new CreateGatheringResponse(
+                gathering.getId(),
+                gathering.getType(),
+                gathering.getDetail().name(),
+                gathering.getOwnerId(),
+                gathering.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/io/github/bunmo/gathering/dto/response/GatheringDetailResponse.java
@@ -58,7 +58,10 @@ public record GatheringDetailResponse(
         List<ParticipantInfo> participantInfos = participantMembers.stream()
                 .map(ParticipantInfo::from)
                 .toList();
-
+        boolean isHost = gathering.getOwnerId().equals(currentMemberId);
+        boolean isParticipant = gathering.getParticipants().stream()
+                .anyMatch(p -> p.getMemberId().equals(currentMemberId));
+        String openChatLink = (isHost || isParticipant) ? gathering.getDetail().openChatLink() : null;
         return new GatheringDetailResponse(
                 gathering.getId(),
                 gathering.getType(),
@@ -69,13 +72,13 @@ public record GatheringDetailResponse(
                 gathering.getMeetingTime(),
                 gathering.getLocation().address(),
                 gathering.getDetail().introduction(),
-                gathering.getDetail().openChatLink(),
+                openChatLink,
                 gathering.getCategory(),
                 gathering.getMaxParticipantCount(),
                 gathering.getParticipants().size(),
                 HostInfo.from(host),
                 participantInfos,
-                gathering.getOwnerId().equals(currentMemberId),
+                isHost,
                 remainingTime,
                 gathering.getCreatedAt()
         );

--- a/src/main/java/io/github/bunmo/gathering/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/io/github/bunmo/gathering/dto/response/GatheringDetailResponse.java
@@ -1,0 +1,97 @@
+package io.github.bunmo.gathering.dto.response;
+
+import io.github.bunmo.gathering.infrastructure.domain.Gathering;
+import io.github.bunmo.gathering.infrastructure.domain.GatheringParticipant;
+import io.github.bunmo.gathering.infrastructure.domain.enums.CategoryType;
+import io.github.bunmo.gathering.infrastructure.domain.enums.GatheringType;
+import io.github.bunmo.member.infrastructure.domain.Member;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public record GatheringDetailResponse(
+        Long id,
+        GatheringType type,
+        String title,
+        BigDecimal price,
+        String productLink,
+        LocalDate meetingDate,
+        LocalTime meetingTime,
+        String location,
+        String description,
+        String openChatLink,
+        CategoryType category,
+        int maxParticipants,
+        int currentParticipants,
+        HostInfo host,
+        List<ParticipantInfo> participants,
+        boolean isHost,
+        String remainingTime,
+        LocalDateTime createdAt
+) {
+    public record HostInfo(Long id, String nickname, String profileImageUrl) {
+        public static HostInfo from(Member member) {
+            return new HostInfo(
+                    member.getId(),
+                    member.getMemberProfile().nickname(),
+                    member.getMemberProfile().profileImageUrl()
+            );
+        }
+    }
+
+    public record ParticipantInfo(Long id, String nickname, String profileImageUrl) {
+        public static ParticipantInfo from(Member member) {
+            return new ParticipantInfo(
+                    member.getId(),
+                    member.getMemberProfile().nickname(),
+                    member.getMemberProfile().profileImageUrl()
+            );
+        }
+    }
+
+    public static GatheringDetailResponse of(Gathering gathering, Member host, List<Member> participantMembers, Long currentMemberId) {
+        String remainingTime = calculateRemainingTime(gathering.getMeetingDate(), gathering.getMeetingTime());
+        List<ParticipantInfo> participantInfos = participantMembers.stream()
+                .map(ParticipantInfo::from)
+                .toList();
+
+        return new GatheringDetailResponse(
+                gathering.getId(),
+                gathering.getType(),
+                gathering.getDetail().name(),
+                gathering.getPrice(),
+                gathering.getProductLink(),
+                gathering.getMeetingDate(),
+                gathering.getMeetingTime(),
+                gathering.getLocation().address(),
+                gathering.getDetail().introduction(),
+                gathering.getDetail().openChatLink(),
+                gathering.getCategory(),
+                gathering.getMaxParticipantCount(),
+                gathering.getParticipants().size(),
+                HostInfo.from(host),
+                participantInfos,
+                gathering.getOwnerId().equals(currentMemberId),
+                remainingTime,
+                gathering.getCreatedAt()
+        );
+    }
+
+    private static String calculateRemainingTime(LocalDate meetingDate, LocalTime meetingTime) {
+        LocalDateTime meetingDateTime = LocalDateTime.of(meetingDate, meetingTime);
+        LocalDateTime now = LocalDateTime.now();
+        if (meetingDateTime.isBefore(now)) {
+            return "모임 시작됨";
+        }
+        long hours = ChronoUnit.HOURS.between(now, meetingDateTime);
+        if (hours < 24) {
+            return hours + "시간";
+        }
+        long days = ChronoUnit.DAYS.between(now, meetingDateTime);
+        return days + "일";
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/dto/response/GatheringListPageResponse.java
+++ b/src/main/java/io/github/bunmo/gathering/dto/response/GatheringListPageResponse.java
@@ -1,0 +1,23 @@
+package io.github.bunmo.gathering.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record GatheringListPageResponse(
+        List<GatheringListResponse> contents,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public static GatheringListPageResponse from(Page<GatheringListResponse> page) {
+        return new GatheringListPageResponse(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/dto/response/GatheringListResponse.java
+++ b/src/main/java/io/github/bunmo/gathering/dto/response/GatheringListResponse.java
@@ -1,0 +1,45 @@
+package io.github.bunmo.gathering.dto.response;
+
+import io.github.bunmo.gathering.infrastructure.domain.Gathering;
+import io.github.bunmo.gathering.infrastructure.domain.enums.GatheringType;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record GatheringListResponse(
+        Long id,
+        GatheringType type,
+        String title,
+        String thumbnailUrl,
+        LocalDate meetingDate,
+        LocalTime meetingTime,
+        String location,
+        BigDecimal pricePerPerson,
+        int currentParticipants,
+        int maxParticipants
+) {
+    public static GatheringListResponse from(Gathering gathering) {
+        int participantCount = gathering.getParticipants().size();
+        BigDecimal pricePerPerson = null;
+        if (gathering.getPrice() != null && participantCount > 0) {
+            pricePerPerson = gathering.getPrice().divide(
+                    BigDecimal.valueOf(participantCount), 0, RoundingMode.CEILING
+            );
+        }
+
+        return new GatheringListResponse(
+                gathering.getId(),
+                gathering.getType(),
+                gathering.getDetail().name(),
+                null,
+                gathering.getMeetingDate(),
+                gathering.getMeetingTime(),
+                gathering.getLocation().address(),
+                pricePerPerson,
+                participantCount,
+                gathering.getMaxParticipantCount()
+        );
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/exception/GatheringErrorCode.java
+++ b/src/main/java/io/github/bunmo/gathering/exception/GatheringErrorCode.java
@@ -1,0 +1,32 @@
+package io.github.bunmo.gathering.exception;
+
+import io.github.bunmo.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatheringErrorCode implements ErrorCode {
+    GATHERING_NOT_FOUND(HttpStatus.NOT_FOUND, "GATHERING_001", "모임을 찾을 수 없습니다."),
+    PRODUCT_LINK_REQUIRED(HttpStatus.BAD_REQUEST, "GATHERING_002", "쇼핑몰 모임은 상품 링크가 필수입니다.");
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus statusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/Gathering.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/Gathering.java
@@ -71,6 +71,11 @@ public class Gathering {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    public void addParticipant(Long memberId) {
+        GatheringParticipant participant = GatheringParticipant.create(this, memberId);
+        this.participants.add(participant);
+    }
+
     public static Gathering create(
             Long ownerId,
             GatheringType type,

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/Gathering.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/Gathering.java
@@ -1,0 +1,100 @@
+package io.github.bunmo.gathering.infrastructure.domain;
+
+import io.github.bunmo.gathering.infrastructure.domain.enums.ActiveType;
+import io.github.bunmo.gathering.infrastructure.domain.enums.CategoryType;
+import io.github.bunmo.gathering.infrastructure.domain.enums.GatheringType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "gathering")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Gathering {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 10)
+    private GatheringType type;
+
+    @Embedded
+    private GatheringDetail detail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 20)
+    private CategoryType category;
+
+    @Column(name = "owner_id", nullable = false)
+    private Long ownerId;
+
+    @OneToMany(mappedBy = "gathering", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GatheringParticipant> participants = new ArrayList<>();
+
+    @Column(name = "max_participant_count", nullable = false)
+    private int maxParticipantCount;
+
+    @Embedded
+    private GatheringLocation location;
+
+    @Column(name = "price")
+    private BigDecimal price;
+
+    @Column(name = "product_link", length = 200)
+    private String productLink;
+
+    @Column(name = "meeting_date", nullable = false)
+    private LocalDate meetingDate;
+
+    @Column(name = "meeting_time", nullable = false)
+    private LocalTime meetingTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "active_type", nullable = false, length = 10)
+    private ActiveType activeType;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static Gathering create(
+            Long ownerId,
+            GatheringType type,
+            GatheringDetail detail,
+            CategoryType category,
+            int maxParticipantCount,
+            GatheringLocation location,
+            BigDecimal price,
+            String productLink,
+            LocalDate meetingDate,
+            LocalTime meetingTime
+    ) {
+        Gathering gathering = new Gathering();
+        gathering.ownerId = ownerId;
+        gathering.type = type;
+        gathering.detail = detail;
+        gathering.category = category;
+        gathering.maxParticipantCount = maxParticipantCount;
+        gathering.location = location;
+        gathering.price = price;
+        gathering.productLink = productLink;
+        gathering.meetingDate = meetingDate;
+        gathering.meetingTime = meetingTime;
+        gathering.activeType = ActiveType.ACTIVE;
+        return gathering;
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringDetail.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringDetail.java
@@ -1,0 +1,15 @@
+package io.github.bunmo.gathering.infrastructure.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record GatheringDetail(
+        @Column(nullable = false, length = 20)
+        String name,
+        @Column(nullable = false, length = 500)
+        String introduction,
+        @Column(name = "open_chat_link", nullable = false, length = 200)
+        String openChatLink
+) {
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringLocation.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringLocation.java
@@ -1,0 +1,17 @@
+package io.github.bunmo.gathering.infrastructure.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.math.BigDecimal;
+
+@Embeddable
+public record GatheringLocation(
+        @Column(nullable = false, precision = 17, scale = 14)
+        BigDecimal x,
+        @Column(nullable = false, precision = 16, scale = 14)
+        BigDecimal y,
+        @Column(nullable = false, length = 20)
+        String address
+) {
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringLocation.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringLocation.java
@@ -11,7 +11,7 @@ public record GatheringLocation(
         BigDecimal x,
         @Column(nullable = false, precision = 16, scale = 14)
         BigDecimal y,
-        @Column(nullable = false, length = 20)
+        @Column(nullable = false, length = 255)
         String address
 ) {
 }

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringParticipant.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/GatheringParticipant.java
@@ -1,0 +1,37 @@
+package io.github.bunmo.gathering.infrastructure.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "gathering_participant")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GatheringParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gathering_id", nullable = false)
+    private Gathering gathering;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    public static GatheringParticipant create(Gathering gathering, Long memberId) {
+        GatheringParticipant participant = new GatheringParticipant();
+        participant.gathering = gathering;
+        participant.memberId = memberId;
+        participant.joinedAt = LocalDateTime.now();
+        return participant;
+    }
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/enums/ActiveType.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/enums/ActiveType.java
@@ -1,0 +1,5 @@
+package io.github.bunmo.gathering.infrastructure.domain.enums;
+
+public enum ActiveType {
+    ACTIVE, DELETED, REPORTED, CLOSED
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/enums/CategoryType.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/enums/CategoryType.java
@@ -1,0 +1,18 @@
+package io.github.bunmo.gathering.infrastructure.domain.enums;
+
+public enum CategoryType {
+    FOOD,
+    DAILY_SUPPLIES,
+    ELECTRONICS,
+    BEAUTY,
+    BABY,
+    KITCHEN,
+    HOBBY,
+    PET,
+    FASHION,
+    FURNITURE,
+    SPORTS,
+    AUTO,
+    BOOK,
+    OFFICE
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/domain/enums/GatheringType.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/domain/enums/GatheringType.java
@@ -1,0 +1,5 @@
+package io.github.bunmo.gathering.infrastructure.domain.enums;
+
+public enum GatheringType {
+    ONLINE, MART, FREE
+}

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/repository/GatheringRepository.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/repository/GatheringRepository.java
@@ -9,16 +9,21 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface GatheringRepository extends JpaRepository<Gathering, Long> {
 
-    @Query("SELECT g FROM Gathering g WHERE g.activeType = :activeType AND (:date IS NULL OR g.meetingDate = :date)")
+    @Query(value = "SELECT g FROM Gathering g WHERE g.activeType = :activeType AND (:date IS NULL OR g.meetingDate = :date)",
+           countQuery = "SELECT COUNT(g) FROM Gathering g WHERE g.activeType = :activeType AND (:date IS NULL OR g.meetingDate = :date)")
     Page<Gathering> findAllByActiveTypeAndDate(
             @Param("activeType") ActiveType activeType,
             @Param("date") LocalDate date,
             Pageable pageable
     );
+
+    @Query("SELECT DISTINCT g FROM Gathering g LEFT JOIN FETCH g.participants WHERE g.id IN :ids")
+    List<Gathering> findAllWithParticipantsByIds(@Param("ids") List<Long> ids);
 
     @Query("SELECT g FROM Gathering g LEFT JOIN FETCH g.participants WHERE g.id = :id AND g.activeType = :activeType")
     Optional<Gathering> findByIdAndActiveType(

--- a/src/main/java/io/github/bunmo/gathering/infrastructure/repository/GatheringRepository.java
+++ b/src/main/java/io/github/bunmo/gathering/infrastructure/repository/GatheringRepository.java
@@ -1,0 +1,28 @@
+package io.github.bunmo.gathering.infrastructure.repository;
+
+import io.github.bunmo.gathering.infrastructure.domain.Gathering;
+import io.github.bunmo.gathering.infrastructure.domain.enums.ActiveType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface GatheringRepository extends JpaRepository<Gathering, Long> {
+
+    @Query("SELECT g FROM Gathering g WHERE g.activeType = :activeType AND (:date IS NULL OR g.meetingDate = :date)")
+    Page<Gathering> findAllByActiveTypeAndDate(
+            @Param("activeType") ActiveType activeType,
+            @Param("date") LocalDate date,
+            Pageable pageable
+    );
+
+    @Query("SELECT g FROM Gathering g LEFT JOIN FETCH g.participants WHERE g.id = :id AND g.activeType = :activeType")
+    Optional<Gathering> findByIdAndActiveType(
+            @Param("id") Long id,
+            @Param("activeType") ActiveType activeType
+    );
+}

--- a/src/main/java/io/github/bunmo/gathering/service/GatheringService.java
+++ b/src/main/java/io/github/bunmo/gathering/service/GatheringService.java
@@ -7,6 +7,7 @@ import io.github.bunmo.gathering.dto.response.GatheringDetailResponse;
 import io.github.bunmo.gathering.dto.response.GatheringListPageResponse;
 import io.github.bunmo.gathering.dto.response.GatheringListResponse;
 import io.github.bunmo.gathering.exception.GatheringErrorCode;
+import io.github.bunmo.member.exception.MemberErrorCode;
 import io.github.bunmo.gathering.infrastructure.domain.Gathering;
 import io.github.bunmo.gathering.infrastructure.domain.GatheringDetail;
 import io.github.bunmo.gathering.infrastructure.domain.GatheringLocation;
@@ -48,7 +49,7 @@ public class GatheringService {
         }
 
         Member member = memberRepository.findByUuid(userDetails.getUuid())
-                .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         Long currentMemberId = member.getId();
 
         GatheringDetail detail = new GatheringDetail(
@@ -77,14 +78,27 @@ public class GatheringService {
                 request.meetingTime()
         );
 
-        return CreateGatheringResponse.from(gatheringRepository.save(gathering));
+        Gathering saved = gatheringRepository.save(gathering);
+        saved.addParticipant(currentMemberId);
+        return CreateGatheringResponse.from(saved);
     }
 
     public GatheringListPageResponse getGatherings(int page, int size, LocalDate date) {
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<GatheringListResponse> result = gatheringRepository
-                .findAllByActiveTypeAndDate(ActiveType.ACTIVE, date, pageable)
-                .map(GatheringListResponse::from);
+        Page<Gathering> gatheringPage = gatheringRepository.findAllByActiveTypeAndDate(ActiveType.ACTIVE, date, pageable);
+
+        // N+1 방지: ID 목록으로 participants를 한 번에 fetch join
+        List<Long> gatheringIds = gatheringPage.getContent().stream()
+                .map(Gathering::getId)
+                .toList();
+        Map<Long, Gathering> gatheringWithParticipants = gatheringIds.isEmpty()
+                ? Collections.emptyMap()
+                : gatheringRepository.findAllWithParticipantsByIds(gatheringIds).stream()
+                        .collect(Collectors.toMap(Gathering::getId, Function.identity()));
+
+        Page<GatheringListResponse> result = gatheringPage.map(g ->
+                GatheringListResponse.from(gatheringWithParticipants.getOrDefault(g.getId(), g))
+        );
         return GatheringListPageResponse.from(result);
     }
 
@@ -92,9 +106,8 @@ public class GatheringService {
         Gathering gathering = gatheringRepository.findByIdAndActiveType(gatheringId, ActiveType.ACTIVE)
                 .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
 
-        // 💡 개선포인트 2: 에러 코드를 분리할 수 있다면 MemberErrorCode.MEMBER_NOT_FOUND 등으로 수정 권장
         Member host = memberRepository.findById(gathering.getOwnerId())
-                .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         List<Long> participantMemberIds = gathering.getParticipants().stream()
                 .map(GatheringParticipant::getMemberId)
@@ -113,7 +126,7 @@ public class GatheringService {
         }
 
         Member currentMember = memberRepository.findByUuid(userDetails.getUuid())
-                .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         Long currentMemberId = currentMember.getId();
 
         return GatheringDetailResponse.of(gathering, host, participantMembers, currentMemberId);

--- a/src/main/java/io/github/bunmo/gathering/service/GatheringService.java
+++ b/src/main/java/io/github/bunmo/gathering/service/GatheringService.java
@@ -1,0 +1,121 @@
+package io.github.bunmo.gathering.service;
+
+import io.github.bunmo.common.exception.BusinessException;
+import io.github.bunmo.gathering.dto.request.CreateGatheringRequest;
+import io.github.bunmo.gathering.dto.response.CreateGatheringResponse;
+import io.github.bunmo.gathering.dto.response.GatheringDetailResponse;
+import io.github.bunmo.gathering.dto.response.GatheringListPageResponse;
+import io.github.bunmo.gathering.dto.response.GatheringListResponse;
+import io.github.bunmo.gathering.exception.GatheringErrorCode;
+import io.github.bunmo.gathering.infrastructure.domain.Gathering;
+import io.github.bunmo.gathering.infrastructure.domain.GatheringDetail;
+import io.github.bunmo.gathering.infrastructure.domain.GatheringLocation;
+import io.github.bunmo.gathering.infrastructure.domain.GatheringParticipant;
+import io.github.bunmo.gathering.infrastructure.domain.enums.ActiveType;
+import io.github.bunmo.gathering.infrastructure.domain.enums.GatheringType;
+import io.github.bunmo.gathering.infrastructure.repository.GatheringRepository;
+import io.github.bunmo.member.infrastructure.domain.Member;
+import io.github.bunmo.member.infrastructure.repository.MemberRepository;
+import io.github.bunmo.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GatheringService {
+
+    private final GatheringRepository gatheringRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public CreateGatheringResponse createGathering(CreateGatheringRequest request, CustomUserDetails userDetails) {
+        if (request.type() == GatheringType.ONLINE && (request.productLink() == null || request.productLink().isBlank())) {
+            throw new BusinessException(GatheringErrorCode.PRODUCT_LINK_REQUIRED);
+        }
+
+        Member member = memberRepository.findByUuid(userDetails.getUuid())
+                .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
+        Long currentMemberId = member.getId();
+
+        GatheringDetail detail = new GatheringDetail(
+                request.title(),
+                request.description(),
+                request.openChatLink()
+        );
+
+        // TODO: 추후 클라이언트에서 위도/경도를 넘겨주도록 변경 시 이 부분 수정 필요
+        GatheringLocation location = new GatheringLocation(
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                request.location()
+        );
+
+        Gathering gathering = Gathering.create(
+                currentMemberId, // DB에서 찾아오던 부분 대체
+                request.type(),
+                detail,
+                request.category(),
+                request.maxParticipants(),
+                location,
+                request.price(),
+                request.productLink(),
+                request.meetingDate(),
+                request.meetingTime()
+        );
+
+        return CreateGatheringResponse.from(gatheringRepository.save(gathering));
+    }
+
+    public GatheringListPageResponse getGatherings(int page, int size, LocalDate date) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<GatheringListResponse> result = gatheringRepository
+                .findAllByActiveTypeAndDate(ActiveType.ACTIVE, date, pageable)
+                .map(GatheringListResponse::from);
+        return GatheringListPageResponse.from(result);
+    }
+
+    public GatheringDetailResponse getGathering(Long gatheringId, CustomUserDetails userDetails) {
+        Gathering gathering = gatheringRepository.findByIdAndActiveType(gatheringId, ActiveType.ACTIVE)
+                .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
+
+        // 💡 개선포인트 2: 에러 코드를 분리할 수 있다면 MemberErrorCode.MEMBER_NOT_FOUND 등으로 수정 권장
+        Member host = memberRepository.findById(gathering.getOwnerId())
+                .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
+
+        List<Long> participantMemberIds = gathering.getParticipants().stream()
+                .map(GatheringParticipant::getMemberId)
+                .toList();
+
+        // 💡 개선포인트 3: 참여자가 0명일 때 쓸데없는 DB 조회를 막는 방어 로직 추가
+        List<Member> participantMembers = Collections.emptyList();
+        if (!participantMemberIds.isEmpty()) {
+            Map<Long, Member> participantMemberMap = memberRepository.findAllById(participantMemberIds).stream()
+                    .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+            participantMembers = participantMemberIds.stream()
+                    .map(participantMemberMap::get)
+                    .filter(Objects::nonNull)
+                    .toList();
+        }
+
+        Member currentMember = memberRepository.findByUuid(userDetails.getUuid())
+                .orElseThrow(() -> new BusinessException(GatheringErrorCode.GATHERING_NOT_FOUND));
+        Long currentMemberId = currentMember.getId();
+
+        return GatheringDetailResponse.of(gathering, host, participantMembers, currentMemberId);
+    }
+}


### PR DESCRIPTION
# 연관된 이슈
- close #27  

# 작업 내용
- 소분모임 생성/목록/상세 조회 API 구현

# 참고 사항
- GatheringLocation의 x, y 좌표는 현재 BigDecimal.ZERO로 임시 처리 — 추후 클라이언트에서 위도/경도를 전달하는 방식으로 수정 필요.
- 방장 조회 시 에러 코드가 GATHERING_NOT_FOUND로 통일되어 있음 — 추후 MemberErrorCode 분리 해야 할듯 합니다.
- 모임 목록 조회에 현재 MY_CREW, PACE 필터는 미구현 

# 리뷰 요구사항
- 리뷰 부탁드립니당 

# 스크린샷 (선택)
